### PR TITLE
Session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,5 @@ $ forge script script/CardManagerModule.s.sol:CardManagerModuleScript --sig "dep
 
 # Session Manager
 ```shell
-$ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $POLYGON_MAINNET_RPC_URL --etherscan-api-key $POLYGON_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+$ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ $ forge script script/UpgradeableCommunityToken.s.sol:UpgradeableCommunityTokenS
 $ forge script script/CommunityModule.s.sol:CommunityModuleScript --sig "deploy()" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```
 
+# Community Module Upgrade (v2)
+```shell
+$ forge script script/upgrade/UpgradeCommunityModule.s.sol:UpgradeCommunityModuleScript --sig "run(address)" "0x7079253c0358eF9Fd87E16488299Ef6e06F403B6" --rpc-url $POLYGON_ZK_MAINNET_RPC_URL --etherscan-api-key $POLYGON_ZK_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ZK_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+```
+
 # Community + Paymaster Module
 ```shell
 $ forge script script/CommunityAndPaymaster.s.sol:CommunityAndPaymasterModuleScript --sig "deploy(address[])" "[]" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
@@ -103,4 +108,9 @@ $ forge script script/AccountFactory.s.sol:AccountFactoryScript --sig "deploy(ad
 # Card Manager
 ```shell
 $ forge script script/CardManagerModule.s.sol:CardManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $ARBITRUM_MAINNET_RPC_URL --etherscan-api-key $ARBITRUM_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $ARBITRUM_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+```
+
+# Session Manager
+```shell
+$ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $POLYGON_MAINNET_RPC_URL --etherscan-api-key $POLYGON_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/README.md
+++ b/README.md
@@ -80,9 +80,14 @@ Add `--broadcast` to the end of the following the actually publish.
 $ forge script script/UpgradeableCommunityToken.s.sol:UpgradeableCommunityTokenScript --sig "deploy(address[], string, string)" "[0x123]" "My Token" "MT" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```
 
-# Community Module + Paymaster
+# Community Module
 ```shell
-$ forge script script/CommunityModule.s.sol:CommunityModuleScript --sig "deploy(address[])" "[]" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+$ forge script script/CommunityModule.s.sol:CommunityModuleScript --sig "deploy()" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+```
+
+# Community + Paymaster Module
+```shell
+$ forge script script/CommunityAndPaymaster.s.sol:CommunityAndPaymasterModuleScript --sig "deploy(address[])" "[]" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```
 
 # Paymaster
@@ -97,5 +102,5 @@ $ forge script script/AccountFactory.s.sol:AccountFactoryScript --sig "deploy(ad
 
 # Card Manager
 ```shell
-$ forge script script/CardManagerModule.s.sol:CardManagerModuleScript --sig "deploy(address)" 0x64B2D50ddc1a20a9b9bAF30f02983ff61B6b9963 --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+$ forge script script/CardManagerModule.s.sol:CardManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $ARBITRUM_MAINNET_RPC_URL --etherscan-api-key $ARBITRUM_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $ARBITRUM_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/README.md
+++ b/README.md
@@ -112,5 +112,10 @@ $ forge script script/CardManagerModule.s.sol:CardManagerModuleScript --sig "dep
 
 # Session Manager
 ```shell
-$ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+$ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --sig "deploy(address)" 0x7079253c0358eF9Fd87E16488299Ef6e06F403B6 --rpc-url $POLYGON_ZK_MAINNET_RPC_URL --etherscan-api-key $POLYGON_ZK_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ZK_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+```
+
+# Session Module Upgrade (v2)
+```shell
+$ forge script script/upgrade/UpgradeSessionManagerModule.s.sol:UpgradeSessionManagerModuleScript --sig "run(address)" "0xE544c1dC66f65967863F03AEdEd38944E6b87309" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ libs = ["lib"]
 optimize = true
 optimizer_runs = 200
 solc = "0.8.20"
+evm_version = "paris"
 
 # oppenzeppelin
 ffi = true

--- a/script/Paymaster.s.sol
+++ b/script/Paymaster.s.sol
@@ -31,7 +31,7 @@ contract PaymasterDeploy is Script {
 			abi.encode(address(implementation), initData)
 		);
 
-		bytes32 salt = keccak256(abi.encodePacked("PAYMASTER_KFMEDIA"));
+		bytes32 salt = keccak256(abi.encodePacked("PAYMASTER_GRATITUDE"));
 
 		// Deploy the proxy using Create2
 		address proxyAddress = Create2(vm.envAddress("CREATE2_FACTORY_ADDRESS")).deploy(salt, proxyBytecode);

--- a/script/SessionManagerModule.s.sol
+++ b/script/SessionManagerModule.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { Script, console } from "forge-std/Script.sol";
+
+import { TwoFAFactory } from "../src/Modules/Session/TwoFAFactory.sol";
+import { SessionManagerModule } from "../src/Modules/Session/SessionManagerModule.sol";
+
+contract SessionManagerModuleScript is Script {
+	function deploy(address communityModule) public returns (SessionManagerModule, TwoFAFactory) {
+		uint256 deployerPrivateKey = isAnvil()
+			? 77_814_517_325_470_205_911_140_941_194_401_928_579_557_062_014_761_831_930_645_393_041_380_819_009_408
+			: vm.envUint("PRIVATE_KEY");
+		address deployer = vm.addr(deployerPrivateKey);
+
+		vm.startBroadcast(deployerPrivateKey);
+
+		if (isAnvil()) {
+			vm.deal(vm.addr(deployerPrivateKey), 100 ether);
+		}
+
+		// Chicken and egg deployment
+		SessionManagerModule sessionManagerModule = new SessionManagerModule();
+
+		// the card factory needs the card manager module address to deploy
+		TwoFAFactory twoFAFactory = new TwoFAFactory(communityModule, address(sessionManagerModule));
+
+		// the card manager module needs the card factory address in order to function
+		sessionManagerModule.initialize(deployer, address(twoFAFactory));
+
+		vm.stopBroadcast();
+
+		console.log("SessionManagerModule created at: ", address(sessionManagerModule));
+		console.log("TwoFAFactory created at: ", address(twoFAFactory));
+
+		return (sessionManagerModule, twoFAFactory);
+	}
+
+	function isAnvil() private view returns (bool) {
+		return block.chainid == 31_337;
+	}
+}

--- a/script/anvil/CardManagerAnvil.s.sol
+++ b/script/anvil/CardManagerAnvil.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import { Script, console } from "forge-std/Script.sol";
 
 import { UpgradeableCommunityTokenScript } from "../UpgradeableCommunityToken.s.sol";
-import { CommunityModuleScript } from "../CommunityModule.s.sol";
+import { CommunityAndPaymasterModuleScript } from "../CommunityAndPaymaster.s.sol";
 import { AccountFactoryScript } from "../AccountFactory.s.sol";
 
 import { AccountFactory } from "../../src/Modules/Community/AccountFactory.sol";
@@ -31,7 +31,7 @@ contract CardManagerAnvilScript is Script {
         address[] memory whitelist = new address[](1);
         whitelist[0] = address(token);
 
-        CommunityModuleScript communityModuleScript = new CommunityModuleScript();
+        CommunityAndPaymasterModuleScript communityModuleScript = new CommunityAndPaymasterModuleScript();
 
         (CommunityModule communityModule, Paymaster paymaster) = communityModuleScript.deploy(whitelist);
 

--- a/script/anvil/CommunityWithToken.s.sol
+++ b/script/anvil/CommunityWithToken.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import { Script, console } from "forge-std/Script.sol";
 
 import { UpgradeableCommunityTokenScript } from "../UpgradeableCommunityToken.s.sol";
-import { CommunityModuleScript } from "../CommunityModule.s.sol";
+import { CommunityAndPaymasterModuleScript } from "../CommunityAndPaymaster.s.sol";
 import { AccountFactoryScript } from "../AccountFactory.s.sol";
 
 import { AccountFactory } from "../../src/Modules/Community/AccountFactory.sol";
@@ -31,9 +31,9 @@ contract CommunityWithTokenScript is Script {
         address[] memory whitelist = new address[](1);
         whitelist[0] = address(token);
 
-        CommunityModuleScript communityModuleScript = new CommunityModuleScript();
+        CommunityAndPaymasterModuleScript communityAndPaymasterModuleScript = new CommunityAndPaymasterModuleScript();
 
-        (CommunityModule communityModule, Paymaster paymaster) = communityModuleScript.deploy(whitelist);
+        (CommunityModule communityModule, Paymaster paymaster) = communityAndPaymasterModuleScript.deploy(whitelist);
 
 		AccountFactoryScript accountFactoryScript = new AccountFactoryScript();
 		AccountFactory accountFactory = accountFactoryScript.deploy(address(communityModule));

--- a/script/upgrade/TestUpgradeSessionManagerModule.s.sol
+++ b/script/upgrade/TestUpgradeSessionManagerModule.s.sol
@@ -1,0 +1,34 @@
+// script/upgrade/TestUpgradeSessionManagerModule.s.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Script, console } from "forge-std/Script.sol";
+import { SessionManagerModule } from "../../src/Modules/Session/SessionManagerModule.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+contract TestUpgradeSessionManagerModuleScript is Script {
+    function testDeploy(address proxyAddress) public returns (SessionManagerModule) {
+        // Deploy the new implementation
+        SessionManagerModule newImplementation = new SessionManagerModule();
+
+        // Upgrade the proxy to the new implementation
+        UUPSUpgradeable proxy = UUPSUpgradeable(proxyAddress);
+        proxy.upgradeToAndCall(
+            address(newImplementation),
+            "" // No initialization function call needed for this upgrade
+        );
+
+        console.log("Test upgraded SessionManagerModule proxy at %s to implementation at %s", proxyAddress, address(newImplementation));
+        
+        return newImplementation;
+    }
+
+    function run(address proxyAddress) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        
+        testDeploy(proxyAddress);
+        
+        vm.stopBroadcast();
+    }
+} 

--- a/script/upgrade/UpgradeCommunityModule.s.sol
+++ b/script/upgrade/UpgradeCommunityModule.s.sol
@@ -1,0 +1,31 @@
+// script/UpgradeCommunityModule.s.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Script, console } from "forge-std/Script.sol";
+import { CommunityModule } from "../../src/Modules/Community/CommunityModule.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { INonceManager } from "account-abstraction/interfaces/INonceManager.sol";
+
+contract UpgradeCommunityModuleScript is Script {
+	function run(address proxyAddress) external {
+		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+		vm.startBroadcast(deployerPrivateKey);
+
+        address entryPoint = vm.envAddress("ERC4337_ENTRYPOINT");
+
+		// Deploy the new implementation
+		CommunityModule newImplementation = new CommunityModule(INonceManager(entryPoint));
+
+		// Upgrade the proxy to the new implementation
+		UUPSUpgradeable proxy = UUPSUpgradeable(proxyAddress);
+		proxy.upgradeToAndCall(
+			address(newImplementation),
+			"" // No initialization function call needed for this upgrade
+		);
+
+		vm.stopBroadcast();
+
+		console.log("Upgraded proxy at %s to implementation at %s", proxyAddress, address(newImplementation));
+	}
+}

--- a/script/upgrade/UpgradeSessionManagerModule.s.sol
+++ b/script/upgrade/UpgradeSessionManagerModule.s.sol
@@ -1,0 +1,28 @@
+// script/upgrade/UpgradeSessionManagerModule.s.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Script, console } from "forge-std/Script.sol";
+import { SessionManagerModule } from "../../src/Modules/Session/SessionManagerModule.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+contract UpgradeSessionManagerModuleScript is Script {
+	function run(address proxyAddress) external {
+		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+		vm.startBroadcast(deployerPrivateKey);
+
+		// Deploy the new implementation
+		SessionManagerModule newImplementation = new SessionManagerModule();
+
+		// Upgrade the proxy to the new implementation
+		UUPSUpgradeable proxy = UUPSUpgradeable(proxyAddress);
+		proxy.upgradeToAndCall(
+			address(newImplementation),
+			"" // No initialization function call needed for this upgrade
+		);
+
+		vm.stopBroadcast();
+
+		console.log("Upgraded SessionManagerModule proxy at %s to implementation at %s", proxyAddress, address(newImplementation));
+	}
+} 

--- a/src/ERC20/UpgradeableCommunityToken.sol
+++ b/src/ERC20/UpgradeableCommunityToken.sol
@@ -20,12 +20,10 @@ contract UpgradeableCommunityToken is
 	UUPSUpgradeable
 {
 	bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-	bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 	bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
     // Custom errors
     error MustHaveMinterRole(address account);
-    error MustHaveBurnerRole(address account);
 
 	function initialize(
 		address _owner,
@@ -41,12 +39,10 @@ contract UpgradeableCommunityToken is
 		_grantRole(DEFAULT_ADMIN_ROLE, _owner);
 
 		_setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
-		_setRoleAdmin(BURNER_ROLE, DEFAULT_ADMIN_ROLE);
 		_setRoleAdmin(PAUSER_ROLE, DEFAULT_ADMIN_ROLE);
 
 		for (uint256 i = 0; i < minters.length; i++) {
 			_grantRole(MINTER_ROLE, minters[i]);
-			_grantRole(BURNER_ROLE, minters[i]);
 		}
 	}
 
@@ -60,7 +56,7 @@ contract UpgradeableCommunityToken is
 	}
 
 	function burnFrom(address from, uint256 amount) public override {
-        if (!hasRole(BURNER_ROLE, msg.sender)) revert MustHaveBurnerRole(msg.sender);
+        if (!hasRole(MINTER_ROLE, msg.sender)) revert MustHaveMinterRole(msg.sender);
 		_burn(from, amount);
 	}
 

--- a/src/Modules/CardManager/CardManagerModule.sol
+++ b/src/Modules/CardManager/CardManagerModule.sol
@@ -83,6 +83,7 @@ contract CardManagerModule is
 	/////////////////////////////////////////////////
 	// EVENTS
 	event InstanceCreated(bytes32 id, address owner);
+	event InstanceContractsUpdated(bytes32 id, address[] contracts);
 	event WhitelistUpdated(bytes32 id, address[] addresses);
 
 	event CardCreated(address indexed card);
@@ -134,6 +135,8 @@ contract CardManagerModule is
 
 	function updateInstanceContracts(bytes32 id, address[] memory contracts) external onlyInstanceOwner(id) {
 		instanceContracts[id] = contracts;
+
+		emit InstanceContractsUpdated(id, contracts);
 	}
 
 	function authorizeNewInstance(

--- a/src/Modules/Community/CommunityModule.sol
+++ b/src/Modules/Community/CommunityModule.sol
@@ -38,7 +38,7 @@ contract CommunityModule is
 	UUPSUpgradeable
 {
 	string public constant NAME = "Community Module";
-	string public constant VERSION = "0.0.1";
+	string public constant VERSION = "0.0.2";
 
 	////////////////
 

--- a/src/Modules/Community/CommunityModule.sol
+++ b/src/Modules/Community/CommunityModule.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.20;
 
 import { Safe, OwnerManager, ModuleManager, Enum } from "safe-smart-account/contracts/Safe.sol";
+import { Guard } from "safe-smart-account/contracts/base/GuardManager.sol";
+import { StorageAccessible } from "safe-smart-account/contracts/common/StorageAccessible.sol";
 import { CompatibilityFallbackHandler } from "safe-smart-account/contracts/handler/CompatibilityFallbackHandler.sol";
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -39,6 +41,9 @@ contract CommunityModule is
 	string public constant VERSION = "0.0.1";
 
 	////////////////
+
+	// keccak256("guard_manager.guard.address")
+	bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
 	bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH =
 		0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
@@ -139,14 +144,29 @@ contract CommunityModule is
 			// verify call data
 			_validateCallData(op);
 
+			// call the initCode
+			if (seq == 0 && !_contractExists(sender)) {
+				_initAccount(op, sender);
+			}
+
+			address guard = _getSafeGuard(sender);
+
+			if (guard != address(0)) {
+				_preCallGuard(guard, to, value, data, op);
+			}
+
 			// verify account
-			_validateAccount(op, sender, seq, key);
+			_validateAccount(op, sender, key);
 
 			// verify paymaster signature
 			_validatePaymasterUserOp(op);
 
 			// execute the op
-			_call(sender, to, value, data);
+			bool success = _call(sender, to, value, data);
+
+			if (guard != address(0)) {
+				_postCallGuard(guard, op, success);
+			}
 
 			unchecked {
 				++i;
@@ -173,12 +193,7 @@ contract CommunityModule is
 	 * @param op The user operation to validate.
 	 * @param sender The address of the sender of the user operation.
 	 */
-	function _validateAccount(UserOperation calldata op, address sender, uint64 seq, uint192 key) internal virtual {
-		// call the initCode
-		if (seq == 0 && !_contractExists(sender)) {
-			_initAccount(op, sender);
-		}
-
+	function _validateAccount(UserOperation calldata op, address sender, uint192 key) internal virtual {
 		// verify the user op signature
 		require(validateUserOp(op, getUserOpHash(op)), "AA24 signature error");
 
@@ -311,6 +326,41 @@ contract CommunityModule is
 		return size > 0;
 	}
 
+	function _getSafeGuard(address safe) internal virtual returns (address) {
+		uint256 offset = uint256(GUARD_STORAGE_SLOT);
+		bytes memory storageData = StorageAccessible(safe).getStorageAt(offset, 1);
+		address guard = address(uint160(uint256(bytes32(storageData))));
+		return guard;
+	}
+
+	function _preCallGuard(
+		address guard,
+		address to,
+		uint256 value,
+		bytes memory data,
+		UserOperation calldata op
+	) internal virtual {
+		address sender = op.getSender();
+
+		Guard(guard).checkTransaction(
+			to,
+			value,
+			data,
+			Enum.Operation.Call,
+			0,
+			0,
+			0,
+			address(0),
+			payable(0),
+			op.signature,
+			sender
+		);
+	}
+
+	function _postCallGuard(address guard, UserOperation calldata op, bool success) internal virtual {
+		Guard(guard).checkAfterExecution(op.hash(), success);
+	}
+
 	/**
 	 * @dev Internal function to call a contract with value and data.
 	 * If the call fails, it reverts with the reason returned by the callee.
@@ -319,7 +369,7 @@ contract CommunityModule is
 	 * @param value The amount of ether to send with the call.
 	 * @param data The data to send with the call.
 	 */
-	function _call(address sender, address to, uint256 value, bytes memory data) internal {
+	function _call(address sender, address to, uint256 value, bytes memory data) internal returns (bool) {
 		(bool success, bytes memory result) = Safe(payable(sender)).execTransactionFromModuleReturnData(
 			to,
 			value,
@@ -331,6 +381,8 @@ contract CommunityModule is
 				revert(add(result, 32), mload(result))
 			}
 		}
+
+		return success;
 	}
 
 	function _authorizeUpgrade(address newImplementation) internal view override onlyOwner {

--- a/src/Modules/Session/SessionManagerModule.sol
+++ b/src/Modules/Session/SessionManagerModule.sol
@@ -40,7 +40,7 @@ contract SessionManagerModule is
 	UUPSUpgradeable
 {
 	string public constant NAME = "Session Module";
-	string public constant VERSION = "0.0.2";
+	string public constant VERSION = "0.0.3";
 
 	////////////////
 

--- a/src/Modules/Session/SessionManagerModule.sol
+++ b/src/Modules/Session/SessionManagerModule.sol
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import { CompatibilityFallbackHandler } from "safe-smart-account/contracts/handler/CompatibilityFallbackHandler.sol";
+import { Enum, ModuleManager, OwnerManager } from "safe-smart-account/contracts/Safe.sol";
+import { BaseGuard, Guard } from "safe-smart-account/contracts/base/GuardManager.sol";
+import { IERC165 } from "safe-smart-account/contracts/interfaces/IERC165.sol";
+import { TokenCallbackHandler } from "safe-smart-account/contracts/handler/TokenCallbackHandler.sol";
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+
+import { TwoFAFactory } from "./TwoFAFactory.sol";
+import { SessionRequest, ActiveSession } from "./SessionRequest.sol";
+
+error ChallengeExpired();
+error SessionOwnerIsProvider();
+error InvalidProvider();
+error SessionRequestNotFound();
+error InvalidOwnerSignedSessionHash();
+error AccountNotCreated();
+error FailedToAddSigner();
+error FailedToRemoveSigner();
+error SignerNotOwner();
+
+error CM10_InstanceAlreadyExists(bytes32 id);
+error CM11_OnlyInstanceOwner(address instanceOwner);
+error CM12_InstanceDoesNotExist(bytes32 id);
+error CM13_InstanceIsPaused(bytes32 id);
+error CM14_InstanceNotAuthorized(bytes32 id);
+error CM15_NoTokensAuthorizedForInstance(bytes32 id);
+error CM16_TokenNotAuthorizedForInstance(bytes32 id, address token);
+error CM20_AddressNotWhitelisted(bytes32 id, address addr);
+error CM33_AccountNotCreated();
+error CM34_FailedToAddOwner();
+error CM40_FailedToWithdraw();
+
+contract SessionManagerModule is
+	CompatibilityFallbackHandler,
+	BaseGuard,
+	Initializable,
+	ReentrancyGuardUpgradeable,
+	OwnableUpgradeable,
+	UUPSUpgradeable
+{
+	string public constant NAME = "Session Module";
+	string public constant VERSION = "0.0.1";
+
+	////////////////
+
+	// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+	bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH =
+		0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+	/// @dev Returns the chain id used by this contract.
+	function getChainId() public view returns (uint256) {
+		uint256 id;
+		// solhint-disable-next-line no-inline-assembly
+		assembly {
+			id := chainid()
+		}
+		return id;
+	}
+
+	function domainSeparator() public view returns (bytes32) {
+		return
+			keccak256(
+				abi.encode(
+					DOMAIN_SEPARATOR_TYPEHASH,
+					keccak256(abi.encodePacked(NAME)),
+					keccak256(abi.encodePacked(VERSION)),
+					getChainId(),
+					// address(communityModule),
+					this
+				)
+			);
+	}
+
+	/////////////////////////////////////////////////
+	// VARIABLES
+	address public twoFAFactory;
+	mapping(address => mapping(bytes32 => SessionRequest)) public sessionRequests;
+	mapping(address => ActiveSession) public activeSessions;
+
+	/////////////////////////////////////////////////
+	// EVENTS
+	event Requested(address indexed provider, bytes32 sessionRequestHash);
+	event Confirmed(address indexed provider, address indexed account, address sessionOwner);
+
+	/////////////////////////////////////////////////
+	// INITIALIZATION
+
+	function initialize(address _owner, address _twoFAFactory) external initializer {
+		__Ownable_init(_owner);
+		__UUPSUpgradeable_init();
+		__ReentrancyGuard_init();
+
+		twoFAFactory = _twoFAFactory;
+	}
+
+	/////////////////////////////////////////////////
+
+	/////////////////////////////////////////////////
+	// UPGRADE AUTHORIZATION
+
+	function _authorizeUpgrade(address newImplementation) internal view override onlyOwner {
+		(newImplementation);
+	}
+
+	/////////////////////////////////////////////////
+
+	/////////////////////////////////////////////////
+	// SESSION MANAGEMENT
+
+	function request(
+		bytes32 sessionSalt,
+		bytes32 sessionRequestHash,
+		bytes calldata signedSessionRequestHash,
+		bytes calldata signedSessionHash,
+		uint48 sessionRequestExpiry
+	) external {
+		// make sure challengeExpiry is in the future
+		if (sessionRequestExpiry > 0 && sessionRequestExpiry < block.timestamp) {
+			revert ChallengeExpired();
+		}
+
+		// provider is sender
+		address provider = msg.sender;
+
+		// get account address and deploy account if it doesn't exist
+		uint256 salt = _bytes32ToUint256(sessionSalt);
+		address account = TwoFAFactory(twoFAFactory).createAccount(provider, salt);
+
+		// recover sessionOwner
+		address sessionOwner = recoverSigner(sessionRequestHash, signedSessionRequestHash);
+
+		// session owner should not be provider
+		if (sessionOwner == provider) {
+			revert SessionOwnerIsProvider();
+		}
+
+		// save session request
+		sessionRequests[provider][sessionRequestHash] = SessionRequest({
+			expiry: sessionRequestExpiry,
+			signedSessionHash: signedSessionHash,
+			owner: sessionOwner,
+			account: account
+		});
+
+		emit Requested(provider, sessionRequestHash);
+	}
+
+	function confirm(bytes32 sessionRequestHash, bytes32 sessionHash, bytes calldata ownerSignedSessionHash) external {
+		// check if session request exists
+		SessionRequest memory sessionRequest = sessionRequests[msg.sender][sessionRequestHash];
+		if (sessionRequest.owner == address(0)) {
+			revert SessionRequestNotFound();
+		}
+
+		// check if session request has expired
+		if (sessionRequest.expiry > 0 && sessionRequest.expiry < block.timestamp) {
+			revert ChallengeExpired();
+		}
+
+		// provider is sender
+		address provider = msg.sender;
+
+		// check if provider is valid
+		address recoveredProvider = recoverSigner(sessionRequestHash, sessionRequest.signedSessionHash);
+		if (recoveredProvider != provider) {
+			revert InvalidProvider();
+		}
+
+		// check if owner signed session hash is valid
+		if (recoverSigner(sessionHash, ownerSignedSessionHash) != sessionRequest.owner) {
+			revert InvalidOwnerSignedSessionHash();
+		}
+
+		// add session owner as signer
+		_addSigner(sessionRequest.account, sessionRequest.owner);
+
+		// set expiry
+		activeSessions[sessionRequest.owner] = ActiveSession({
+			owner: sessionRequest.owner,
+			account: sessionRequest.account,
+			expiry: sessionRequest.expiry
+		});
+
+		// delete session request
+		delete sessionRequests[provider][sessionRequestHash];
+
+		emit Confirmed(provider, sessionRequest.account, sessionRequest.owner);
+	}
+
+	function _getAccountAddress(bytes32 sessionSalt) internal view returns (address) {
+		uint256 salt = _bytes32ToUint256(sessionSalt);
+
+		address accountAddress = TwoFAFactory(twoFAFactory).getAddress(address(this), salt);
+
+		return accountAddress;
+	}
+
+	function _bytes32ToUint256(bytes32 b) internal pure returns (uint256) {
+		return uint256(b);
+	}
+
+	/////////////////////////////////////////////////
+	// ACCOUNT OWNERSHIP
+
+	function _addSigner(address account, address newSigner) internal {
+		if (!contractExists(account)) {
+			revert AccountNotCreated();
+		}
+
+		uint256 threshold = OwnerManager(account).getThreshold();
+
+		bytes memory data = abi.encodeCall(OwnerManager.addOwnerWithThreshold, (newSigner, threshold));
+
+		bool success = ModuleManager(account).execTransactionFromModule(account, 0, data, Enum.Operation.Call);
+		if (!success) {
+			revert FailedToAddSigner();
+		}
+	}
+
+	function _removeSigner(address account, address signer) internal {
+		OwnerManager ownerManager = OwnerManager(account);
+
+		if (!ownerManager.isOwner(signer)) {
+			revert SignerNotOwner();
+		}
+
+		uint256 threshold = ownerManager.getThreshold();
+
+		// Need to find the previous owner in the linked list
+		address[] memory owners = ownerManager.getOwners();
+		address prevOwner = address(0);
+		address currentOwner = signer;
+
+		// Traverse the linked list to find the previous owner
+		for (uint256 i = 0; i < owners.length; i++) {
+			if (owners[i] == signer) {
+				// If signer is the first owner in the array, prevOwner should remain SENTINEL_OWNERS
+				if (i > 0) {
+					prevOwner = owners[i - 1];
+				}
+				break;
+			}
+		}
+
+		bytes memory data = abi.encodeCall(OwnerManager.removeOwner, (prevOwner, currentOwner, threshold));
+
+		bool success = ModuleManager(account).execTransactionFromModule(account, 0, data, Enum.Operation.Call);
+		if (!success) {
+			revert FailedToRemoveSigner();
+		}
+	}
+
+	/////////////////////////////////////////////////
+	// Session Management
+
+	function removeExpiredSessions(address signer) public {
+		if (activeSessions[signer].expiry > 0 && activeSessions[signer].expiry < block.timestamp) {
+			_removeSigner(activeSessions[signer].account, signer);
+
+			delete activeSessions[signer];
+		}
+	}
+
+	/////////////////////////////////////////////////
+
+	/////////////////////////////////////////////////
+	// Guard
+
+	function checkTransaction(
+		address /*to*/,
+		uint256 /*value*/,
+		bytes memory /*data*/,
+		Enum.Operation operation,
+		uint256 /*safeTxGas*/,
+		uint256 /*baseGas*/,
+		uint256 /*gasPrice*/,
+		address /*gasToken*/,
+		address payable /*refundReceiver*/,
+		bytes memory /*signatures*/,
+		address /*msgSender*/
+	) external {
+		removeExpiredSessions(msg.sender);
+	}
+
+	function checkAfterExecution(bytes32 txHash, bool success) external {}
+
+	function supportsInterface(
+		bytes4 interfaceId
+	) external view virtual override(BaseGuard, TokenCallbackHandler) returns (bool) {
+		return
+			interfaceId == type(Guard).interfaceId || // 0xe6d7a83a
+			interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
+	}
+
+	/////////////////////////////////////////////////
+
+	/////////////////////////////////////////////////
+	// HELPERS
+
+	function contractExists(address contractAddress) public view returns (bool) {
+		uint256 size;
+		// solhint-disable-next-line no-inline-assembly
+		assembly {
+			size := extcodesize(contractAddress)
+		}
+		return size > 0;
+	}
+
+	function readBytes32(bytes memory data, uint256 index) internal pure returns (bytes32 result) {
+		require(data.length >= index + 32, "readBytes32: invalid data length");
+		assembly {
+			result := mload(add(data, add(32, index)))
+		}
+	}
+
+	/**
+	 * @notice Recover the signer of hash, assuming it's an EOA account
+	 * @dev Only for EthSign signatures
+	 * @param _hash       Hash of message that was signed
+	 * @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
+	 */
+	function recoverSigner(bytes32 _hash, bytes memory _signature) internal pure returns (address signer) {
+		require(_signature.length == 65, "SignatureValidator#recoverSigner: invalid signature length");
+
+		// Variables are not scoped in Solidity.
+		uint8 v = uint8(_signature[64]);
+		bytes32 r = readBytes32(_signature, 0);
+		bytes32 s = readBytes32(_signature, 32);
+
+		// EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+		// unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+		// the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+		// signatures from current libraries generate a unique signature with an s-value in the lower half order.
+		//
+		// If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+		// with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+		// vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+		// these malleable signatures as well.
+		//
+		// Source OpenZeppelin
+		// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol
+
+		if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+			revert("SignatureValidator#recoverSigner: invalid signature 's' value");
+		}
+
+		if (v != 27 && v != 28) {
+			revert("SignatureValidator#recoverSigner: invalid signature 'v' value");
+		}
+
+		// Recover ECDSA signer
+		signer = ecrecover(_hash, v, r, s);
+
+		// Prevent signer from being 0x0
+		require(signer != address(0x0), "SignatureValidator#recoverSigner: INVALID_SIGNER");
+
+		return signer;
+	}
+
+	/////////////////////////////////////////////////
+}

--- a/src/Modules/Session/SessionManagerModule.sol
+++ b/src/Modules/Session/SessionManagerModule.sol
@@ -126,6 +126,7 @@ contract SessionManagerModule is
 		bytes calldata signedSessionHash,
 		uint48 sessionRequestExpiry
 	) external {
+		// TODO: add a uint48 challengeExpiry as well to expire the session request after a certain time, ok for now
 		// make sure challengeExpiry is in the future
 		if (sessionRequestExpiry > 0 && sessionRequestExpiry < block.timestamp) {
 			revert SessionRequestExpired();

--- a/src/Modules/Session/SessionManagerModule.sol
+++ b/src/Modules/Session/SessionManagerModule.sol
@@ -39,7 +39,7 @@ contract SessionManagerModule is
 	UUPSUpgradeable
 {
 	string public constant NAME = "Session Module";
-	string public constant VERSION = "0.0.1";
+	string public constant VERSION = "0.0.2";
 
 	////////////////
 

--- a/src/Modules/Session/SessionManagerModule.sol
+++ b/src/Modules/Session/SessionManagerModule.sol
@@ -28,18 +28,6 @@ error FailedToAddSigner();
 error FailedToRemoveSigner();
 error SignerNotOwner();
 
-error CM10_InstanceAlreadyExists(bytes32 id);
-error CM11_OnlyInstanceOwner(address instanceOwner);
-error CM12_InstanceDoesNotExist(bytes32 id);
-error CM13_InstanceIsPaused(bytes32 id);
-error CM14_InstanceNotAuthorized(bytes32 id);
-error CM15_NoTokensAuthorizedForInstance(bytes32 id);
-error CM16_TokenNotAuthorizedForInstance(bytes32 id, address token);
-error CM20_AddressNotWhitelisted(bytes32 id, address addr);
-error CM33_AccountNotCreated();
-error CM34_FailedToAddOwner();
-error CM40_FailedToWithdraw();
-
 contract SessionManagerModule is
 	CompatibilityFallbackHandler,
 	BaseGuard,

--- a/src/Modules/Session/SessionRequest.sol
+++ b/src/Modules/Session/SessionRequest.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+struct SessionRequest {
+	uint48 expiry;
+	bytes signedSessionHash;
+	address owner;
+    address account;
+}
+
+struct ActiveSession {
+	uint48 expiry;
+	address owner;
+	address account;
+}

--- a/src/Modules/Session/SessionRequest.sol
+++ b/src/Modules/Session/SessionRequest.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 struct SessionRequest {
 	uint48 expiry;
 	bytes signedSessionHash;
+	address provider;
 	address owner;
     address account;
 }

--- a/src/Modules/Session/TwoFAFactory.sol
+++ b/src/Modules/Session/TwoFAFactory.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Safe, ModuleManager } from "safe-smart-account/contracts/Safe.sol";
+import { SafeProxyFactory } from "safe-smart-account/contracts/proxies/SafeProxyFactory.sol";
+import { SafeProxy } from "safe-smart-account/contracts/proxies/SafeProxy.sol";
+
+import { SafeSuiteLib } from "../../utils/SafeSuiteLib.sol";
+
+contract TwoFAFactory is SafeProxyFactory {
+	address immutable public COMMUNITY_MODULE;
+	address immutable public SESSION_MANAGER_MODULE;
+
+	string public constant NAME = "2FA Factory";
+	string public constant VERSION = "0.0.1";
+
+	constructor(address _communityModule, address _sessionManagerModule) {
+		COMMUNITY_MODULE = _communityModule;
+		SESSION_MANAGER_MODULE = _sessionManagerModule;
+	}
+
+	/**
+	 * @notice Creates a new account
+	 * @dev This function creates a new account by deploying a Safe proxy and enabling the CommunityModule
+	 * @param _provider The address of the account owner
+	 * @param _salt A unique number to ensure different salts for the same owner
+	 * @return address The address of the created account
+	 */
+	function createAccount(address _provider, uint256 _salt) external returns (address) {
+		// compute the address of the account
+		address safeAddress = getAddress(_provider, _salt);
+		// check if the account already exists
+		if (isContract(safeAddress)) {
+			// skip the deployment
+			return safeAddress;
+		}
+
+		bytes memory safeInitializer = _getInitializer(safeAddress);
+		bytes32 salt = _getSalt(_provider, _salt);
+
+		// Deploy Safe proxy
+		SafeProxy safeProxy = deployProxy(SafeSuiteLib.SAFE_Safe_ADDRESS, safeInitializer, salt);
+
+		emit ProxyCreation(safeProxy, SafeSuiteLib.SAFE_Safe_ADDRESS);
+
+		return address(safeProxy);
+	}
+
+	/**
+	 * @notice Computes the address of a proxy that would be created using CREATE2
+	 * @param _provider Address of the owner
+	 * @param _salt Nonce that will be used to generate the salt
+	 * @return The computed address of the proxy
+	 */
+	function getAddress(address _provider, uint256 _salt) public view returns (address) {
+		bytes32 create2Input = _getCreate2Input(_provider, _salt);
+
+		return address(uint160(uint256(create2Input)));
+	}
+
+	/**
+	 * @notice Generates a unique salt for CREATE2 deployment
+	 * @dev This function combines the owner's address and a nonce to create a unique identifier
+	 * @param _provider The address of the account owner
+	 * @param _salt A unique number to ensure different salts for the same owner
+	 * @return bytes32 A unique salt value used in CREATE2 deployment
+	 */
+	function _getSalt(address _provider, uint256 _salt) internal pure returns (bytes32) {
+		return keccak256(abi.encodePacked(_provider, _salt));
+	}
+
+	/**
+	 * @notice Generates the CREATE2 input for the Safe proxy
+	 * @dev This function combines the proxy creation code and the salt to generate a unique identifier
+	 * @param _provider The address of the account owner
+	 * @param _salt A unique number to ensure different salts for the same owner
+	 * @return bytes32 The CREATE2 input value used in the proxy creation
+	 */
+	function _getCreate2Input(address _provider, uint256 _salt) internal view returns (bytes32) {
+		bytes32 salt = _getSalt(_provider, _salt);
+
+		return
+			keccak256(
+				abi.encodePacked(
+					bytes1(0xff),
+					address(this),
+					salt,
+					keccak256(abi.encodePacked(proxyCreationCode(), uint256(uint160(SafeSuiteLib.SAFE_Safe_ADDRESS))))
+				)
+			);
+	}
+
+	/**
+	 * @notice Generates the initializer data for the Safe proxy
+	 * @dev This function sets up the Safe with the necessary owners and modules
+	 * @param _safe The address of the Safe proxy
+	 * @return bytes memory The initializer data for the Safe proxy
+	 */
+	function _getInitializer(address _safe) internal view returns (bytes memory) {
+		address[] memory owners = new address[](0);
+
+		address[] memory modules = new address[](2);
+		modules[0] = COMMUNITY_MODULE;
+		modules[1] = SESSION_MANAGER_MODULE;
+
+		// Prepare the data to call enableModule on the CommunityModule
+		// Encode the enableModule function call
+		bytes memory enableModuleData = abi.encodeCall(this.enableModules, (_safe, modules));
+
+		// Prepare safe initializer data
+		bytes memory safeInitializer = abi.encodeWithSelector(
+			Safe.setup.selector,
+			owners,
+			1, // threshold
+			address(this), // to
+			enableModuleData, // data
+			// address(0), // to
+			// "", // data
+			SafeSuiteLib.SAFE_TokenCallbackHandler_ADDRESS, // fallbackHandler
+			address(0), // paymentToken
+			0, // payment
+			address(0) // paymentReceiver
+		);
+		return safeInitializer;
+	}
+
+	/**
+	 * @notice Enables modules on the Safe proxy
+	 * @dev Can only be called as a part of the initialization process of a Safe
+	 * @param _safe The address of the Safe proxy
+	 * @param _safeModules The address of the modules to enable
+	 */
+	function enableModules(address _safe, address[] memory _safeModules) public payable {
+		Safe safe = Safe(payable(_safe));
+
+		for (uint256 i = 0; i < _safeModules.length; i++) {
+			address module = _safeModules[i];
+
+			// Check if the module is already enabled
+			if (ModuleManager(payable(safe)).isModuleEnabled(module)) {
+				continue;
+			}
+
+			ModuleManager(payable(safe)).enableModule(module);
+		}
+	}
+}

--- a/test/CardManagerModule.t.sol
+++ b/test/CardManagerModule.t.sol
@@ -15,7 +15,7 @@ import { SafeSuiteSetupScript } from "../script/SafeSuiteSetup.s.sol";
 import { AccountFactoryScript } from "../script/AccountFactory.s.sol";
 import { CardManagerModuleScript } from "../script/CardManagerModule.s.sol";
 import { DeploymentScript } from "../script/Deployment.s.sol";
-import { CommunityModuleScript } from "../script/CommunityModule.s.sol";
+import { CommunityAndPaymasterModuleScript } from "../script/CommunityAndPaymaster.s.sol";
 import { UpgradeableCommunityTokenScript } from "../script/UpgradeableCommunityToken.s.sol";
 
 import { CommunityModule } from "../src/Modules/Community/CommunityModule.sol";
@@ -84,8 +84,8 @@ contract CardManagerModuleTest is Test {
 		address[] memory whitelistedAddresses = new address[](1);
 		whitelistedAddresses[0] = address(token);
 
-		CommunityModuleScript communityModuleScript = new CommunityModuleScript();
-		(communityModule, paymaster) = communityModuleScript.deploy(whitelistedAddresses);
+		CommunityAndPaymasterModuleScript communityAndPaymasterModuleScript = new CommunityAndPaymasterModuleScript();
+		(communityModule, paymaster) = communityAndPaymasterModuleScript.deploy(whitelistedAddresses);
 
 		// Deploy the account factory
 		AccountFactoryScript accountFactoryScript = new AccountFactoryScript();

--- a/test/CommunityModule.t.sol
+++ b/test/CommunityModule.t.sol
@@ -14,7 +14,7 @@ import { Utils } from "./utils/Utils.sol";
 import { SafeSuiteSetupScript } from "../script/SafeSuiteSetup.s.sol";
 import { AccountFactoryScript } from "../script/AccountFactory.s.sol";
 import { DeploymentScript } from "../script/Deployment.s.sol";
-import { CommunityModuleScript } from "../script/CommunityModule.s.sol";
+import { CommunityAndPaymasterModuleScript } from "../script/CommunityAndPaymaster.s.sol";
 import { UpgradeableCommunityTokenScript } from "../script/UpgradeableCommunityToken.s.sol";
 
 import { CommunityModule } from "../src/Modules/Community/CommunityModule.sol";
@@ -67,8 +67,8 @@ contract CommunityModuleTest is Test {
 		address[] memory whitelistedAddresses = new address[](1);
 		whitelistedAddresses[0] = address(token);
 
-		CommunityModuleScript communityModuleScript = new CommunityModuleScript();
-		(communityModule, paymaster) = communityModuleScript.deploy(whitelistedAddresses);
+		CommunityAndPaymasterModuleScript communityAndPaymasterModuleScript = new CommunityAndPaymasterModuleScript();
+		(communityModule, paymaster) = communityAndPaymasterModuleScript.deploy(whitelistedAddresses);
 
 		// Deploy the account factory
 		AccountFactoryScript accountFactoryScript = new AccountFactoryScript();

--- a/test/SessionManagerModule.t.sol
+++ b/test/SessionManagerModule.t.sol
@@ -16,7 +16,7 @@ import { SafeSuiteSetupScript } from "../script/SafeSuiteSetup.s.sol";
 import { AccountFactoryScript } from "../script/AccountFactory.s.sol";
 import { SessionManagerModuleScript } from "../script/SessionManagerModule.s.sol";
 import { DeploymentScript } from "../script/Deployment.s.sol";
-import { CommunityModuleScript } from "../script/CommunityModule.s.sol";
+import { CommunityAndPaymasterModuleScript } from "../script/CommunityAndPaymaster.s.sol";
 import { UpgradeableCommunityTokenScript } from "../script/UpgradeableCommunityToken.s.sol";
 
 import { CommunityModule } from "../src/Modules/Community/CommunityModule.sol";
@@ -94,8 +94,8 @@ contract SessionManagerModuleTest is Test {
 		address[] memory whitelistedAddresses = new address[](1);
 		whitelistedAddresses[0] = address(token);
 
-		CommunityModuleScript communityModuleScript = new CommunityModuleScript();
-		(communityModule, paymaster) = communityModuleScript.deploy(whitelistedAddresses);
+		CommunityAndPaymasterModuleScript communityAndPaymasterModuleScript = new CommunityAndPaymasterModuleScript();
+		(communityModule, paymaster) = communityAndPaymasterModuleScript.deploy(whitelistedAddresses);
 
 		// Deploy the account factory
 		AccountFactoryScript accountFactoryScript = new AccountFactoryScript();

--- a/test/SessionManagerModule.t.sol
+++ b/test/SessionManagerModule.t.sol
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import { Utils } from "./utils/Utils.sol";
+
+import { INonceManager } from "account-abstraction/interfaces/INonceManager.sol";
+import { UserOperation } from "account-abstraction/interfaces/UserOperation.sol";
+import { Safe, ModuleManager, OwnerManager, GuardManager, Enum } from "safe-smart-account/contracts/Safe.sol";
+import { StorageAccessible } from "safe-smart-account/contracts/common/StorageAccessible.sol";
+import { SafeProxyFactory } from "safe-smart-account/contracts/proxies/SafeProxyFactory.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+import { SafeSuiteSetupScript } from "../script/SafeSuiteSetup.s.sol";
+import { AccountFactoryScript } from "../script/AccountFactory.s.sol";
+import { SessionManagerModuleScript } from "../script/SessionManagerModule.s.sol";
+import { DeploymentScript } from "../script/Deployment.s.sol";
+import { CommunityModuleScript } from "../script/CommunityModule.s.sol";
+import { UpgradeableCommunityTokenScript } from "../script/UpgradeableCommunityToken.s.sol";
+
+import { CommunityModule } from "../src/Modules/Community/CommunityModule.sol";
+import { Paymaster } from "../src/Modules/Community/Paymaster.sol";
+import { TwoFAFactory } from "../src/Modules/Session/TwoFAFactory.sol";
+import { AccountFactory } from "../src/Modules/Community/AccountFactory.sol";
+import { SessionManagerModule } from "../src/Modules/Session/SessionManagerModule.sol";
+import { UpgradeableCommunityToken } from "../src/ERC20/UpgradeableCommunityToken.sol";
+
+import { toEthSignedMessageHash } from "../src/utils/Helpers.sol";
+
+contract SessionManagerModuleTest is Test {
+	uint256 public ownerPrivateKey;
+	address public owner;
+
+	UpgradeableCommunityTokenScript upgradeableCommunityTokenScript;
+
+	Utils public utils = new Utils();
+	// keccak256("guard_manager.guard.address")
+    bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+	CommunityModule public communityModule;
+	Paymaster public paymaster;
+	SessionManagerModule public sessionManagerModule;
+	AccountFactory public accountFactory;
+	TwoFAFactory public twoFAFactory;
+	UpgradeableCommunityToken public token;
+	UpgradeableCommunityToken public token2;
+	address public safeSingleton;
+
+	address[] public accounts;
+	bytes32 public sessionSalt1;
+	address public account1;
+	bytes32 public sessionSalt2;
+	address public account2;
+
+	uint256 public vendorPrivateKey;
+	address public vendor;
+
+	uint256 public badVendorPrivateKey;
+	address public badVendor;
+
+	address[] public modules;
+
+	uint256 private constant VALID_TIMESTAMP_OFFSET = 20;
+
+	uint256 private constant SIGNATURE_OFFSET = 84;
+
+	function _bytes32ToUint256(bytes32 b) public pure returns (uint256) {
+		return uint256(b);
+	}
+
+	function setUp() public {
+		ownerPrivateKey = isAnvil()
+			? 77_814_517_325_470_205_911_140_941_194_401_928_579_557_062_014_761_831_930_645_393_041_380_819_009_408
+			: vm.envUint("PRIVATE_KEY");
+		owner = vm.addr(ownerPrivateKey);
+
+		vm.deal(owner, 100 ether);
+
+		// Deploy the safe singleton
+		SafeSuiteSetupScript setupScript = new SafeSuiteSetupScript();
+		setupScript.run();
+
+		safeSingleton = setupScript.SAFE_SINGLETON_ADDRESS();
+
+		DeploymentScript deploymentScript = new DeploymentScript();
+		deploymentScript.fundDeployer();
+
+		// Deploy the community module
+		upgradeableCommunityTokenScript = new UpgradeableCommunityTokenScript();
+		token2 = upgradeableCommunityTokenScript.testDeploy();
+		token = upgradeableCommunityTokenScript.testDeploy();
+
+		address[] memory whitelistedAddresses = new address[](1);
+		whitelistedAddresses[0] = address(token);
+
+		CommunityModuleScript communityModuleScript = new CommunityModuleScript();
+		(communityModule, paymaster) = communityModuleScript.deploy(whitelistedAddresses);
+
+		// Deploy the account factory
+		AccountFactoryScript accountFactoryScript = new AccountFactoryScript();
+		accountFactory = accountFactoryScript.deploy(address(communityModule));
+
+		// Deploy the session manager module
+		SessionManagerModuleScript sessionManagerModuleScript = new SessionManagerModuleScript();
+		(sessionManagerModule, twoFAFactory) = sessionManagerModuleScript.deploy(address(communityModule));
+
+		modules = new address[](2);
+		modules[0] = address(communityModule);
+		modules[1] = address(sessionManagerModule);
+
+		vm.startBroadcast(ownerPrivateKey);
+
+		// make sure the session manager module is whitelisted
+		whitelistedAddresses = new address[](3);
+		whitelistedAddresses[0] = address(token);
+		whitelistedAddresses[1] = address(token2);
+		whitelistedAddresses[2] = address(sessionManagerModule);
+
+		paymaster.updateWhitelist(whitelistedAddresses);
+
+		vendorPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901234;
+		vendor = accountFactory.createAccount(vm.addr(vendorPrivateKey), 0);
+
+		badVendorPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901235;
+		badVendor = accountFactory.createAccount(vm.addr(badVendorPrivateKey), 0);
+
+		sessionSalt1 = keccak256(abi.encodePacked("+32478121212:sms"));
+		twoFAFactory.createAccount(owner, _bytes32ToUint256(sessionSalt1));
+		account1 = twoFAFactory.getAddress(owner, _bytes32ToUint256(sessionSalt1));
+
+		sessionSalt2 = keccak256(abi.encodePacked("+32478343434:sms"));
+		twoFAFactory.createAccount(owner, _bytes32ToUint256(sessionSalt2));
+		account2 = twoFAFactory.getAddress(owner, _bytes32ToUint256(sessionSalt2));
+
+		accounts = new address[](2);
+		accounts[0] = account1;
+		accounts[1] = account2;
+
+		vm.stopBroadcast();
+
+		upgradeableCommunityTokenScript.mint(account1, 100000000);
+	}
+
+	function testTwoFAFactory() public view {
+		assertEq(
+			twoFAFactory.getAddress(owner, _bytes32ToUint256(sessionSalt1)),
+			account1,
+			"Account should be created"
+		);
+		assertEq(
+			twoFAFactory.getAddress(owner, _bytes32ToUint256(sessionSalt2)),
+			account2,
+			"Account should be created"
+		);
+	}
+
+	function testCommunityModuleIsEnabled() public view {
+		bool isEnabled = ModuleManager(payable(account1)).isModuleEnabled(address(communityModule));
+		assertTrue(isEnabled, "CommunityModule should be enabled for the Safe");
+	}
+
+	function testModulesAreEnabled() public view {
+		for (uint256 i = 0; i < modules.length; i++) {
+			for (uint256 j = 0; j < accounts.length; j++) {
+				bool isEnabled = ModuleManager(payable(accounts[j])).isModuleEnabled(modules[i]);
+				assertTrue(isEnabled, "Module should be enabled for the Safe");
+			}
+		}
+	}
+
+	function testGuardIsSet() public view {
+		for (uint256 i = 0; i < accounts.length; i++) {
+			// Convert bytes32 storage slot to uint256 offset
+			uint256 offset = uint256(GUARD_STORAGE_SLOT);
+			bytes memory storageData = StorageAccessible(accounts[i]).getStorageAt(offset, 1);
+			address guard = address(uint160(uint256(bytes32(storageData))));
+			assertEq(guard, address(sessionManagerModule), "Guard should be set to the session manager module");
+		}
+	}
+
+	function testInitialNonce() public view {
+		for (uint256 i = 0; i < accounts.length; i++) {
+			uint256 nonce = communityModule.getNonce(accounts[i], 0);
+			assertEq(nonce, 0, "Nonce should be 0");
+		}
+	}
+
+	function testAccountFactory() public {
+		address userA = utils.getNextUserAddress();
+
+		address counterFactualSafeA = twoFAFactory.getAddress(userA, 0);
+
+		address safeA = twoFAFactory.createAccount(userA, 0);
+		assertEq(safeA, counterFactualSafeA, "Account factory address should be that of deployed account factory");
+	}
+
+	function testTokenBalance() public view {
+		assertEq(token.balanceOf(account1), 100000000, "Balance should be 100000000");
+		assertEq(token.balanceOf(account2), 0, "Balance should be 0");
+	}
+
+	function testAddingASession() public {
+		uint256 sessionPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901236;
+		address sessionOwner = vm.addr(sessionPrivateKey);
+
+		OwnerManager ownerManager = OwnerManager(account1);
+		assertEq(ownerManager.isOwner(sessionOwner), false, "Session owner should not be an owner");
+
+		uint48 expiry = uint48(block.timestamp + 300);
+
+		_addSession(sessionPrivateKey, ownerPrivateKey, sessionSalt1, expiry);
+
+		assertEq(ownerManager.isOwner(sessionOwner), true, "Session owner should be an owner");
+	}
+
+	function testTransfer() public {
+		uint256 sessionPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901236;
+
+		uint48 expiry = uint48(block.timestamp + 300);
+
+		_addSession(sessionPrivateKey, ownerPrivateKey, sessionSalt1, expiry);
+
+		bytes memory initCode = bytes("");
+
+		bytes memory transferData = abi.encodeWithSignature("transfer(address,uint256)", account2, 100000000);
+
+		UserOperation memory userOp = createUserOperation(account1, initCode, address(token), transferData);
+
+		console.log("******SESSION MANAGER MODULE******", address(sessionManagerModule));
+
+		(userOp.paymasterAndData, userOp.signature) = signUserOp(userOp, sessionPrivateKey);
+		executeUserOp(userOp);
+
+		assertEq(token.balanceOf(account1), 0, "Balance should be 0");
+		assertEq(token.balanceOf(account2), 100000000, "Balance should be 100000000");
+	}
+
+	function testNoSessionTransfer() public {
+		uint256 sessionPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901236;
+
+		bytes memory initCode = bytes("");
+
+		bytes memory transferData = abi.encodeWithSignature("transfer(address,uint256)", account2, 100000000);
+
+		UserOperation memory userOp = createUserOperation(account1, initCode, address(token), transferData);
+
+		(userOp.paymasterAndData, userOp.signature) = signUserOp(userOp, sessionPrivateKey);
+
+		vm.expectRevert("AA24 signature error");
+		executeUserOp(userOp);
+
+		assertEq(token.balanceOf(account1), 100000000, "Balance should be 100000000");
+		assertEq(token.balanceOf(account2), 0, "Balance should be 0");
+	}
+
+	function testExpiredSessionTransfer() public {
+		uint256 sessionPrivateKey = 0x1234567890123456789012345678901234567890123456789012345678901236;
+
+		uint48 expiry = uint48(block.timestamp + 2);
+
+		_addSession(sessionPrivateKey, ownerPrivateKey, sessionSalt1, expiry);
+
+		vm.warp(block.timestamp + 3);
+
+		bytes memory initCode = bytes("");
+
+		bytes memory transferData = abi.encodeWithSignature("transfer(address,uint256)", account2, 100000000);
+
+		UserOperation memory userOp = createUserOperation(account1, initCode, address(token), transferData);
+
+		(userOp.paymasterAndData, userOp.signature) = signUserOp(userOp, sessionPrivateKey);
+		vm.expectRevert("AA24 signature error");
+		executeUserOp(userOp);
+
+		assertEq(token.balanceOf(account1), 100000000, "Balance should be 100000000");
+		assertEq(token.balanceOf(account2), 0, "Balance should be 0");
+	}
+
+	function _addSession(uint256 sessionPrivateKey, uint256 providerPrivateKey, bytes32 sessionSalt, uint48 expiry) private {
+		address sessionOwner = vm.addr(sessionPrivateKey);
+		
+		console.log("SESSION OWNER", sessionOwner);
+
+		// Create session request hash and signature
+		bytes32 sessionRequestHash = createSessionRequestHash(owner, sessionOwner, sessionSalt1, expiry);
+		bytes memory signedSessionRequestHash = _signMessage(sessionPrivateKey, sessionRequestHash);
+
+		// Create session hash and signatures
+		bytes32 challengeHash = keccak256(abi.encodePacked(uint256(123456)));
+		bytes32 sessionHash = createSessionHash(sessionRequestHash, challengeHash);
+
+		bytes memory providerSignedSessionHash = _signMessage(ownerPrivateKey, sessionHash);
+		bytes memory sessionOwnerSignedSessionHash = _signMessage(sessionPrivateKey, sessionHash);
+
+		vm.startBroadcast(providerPrivateKey);
+		sessionManagerModule.request(
+			sessionSalt,
+			sessionRequestHash,
+			signedSessionRequestHash,
+			providerSignedSessionHash,
+			expiry
+		);
+		sessionManagerModule.confirm(sessionRequestHash, sessionHash, sessionOwnerSignedSessionHash);
+		vm.stopBroadcast();
+	}
+
+	// Helper function to sign a message and return the signature
+	function _signMessage(uint256 privateKey, bytes32 messageHash) internal pure returns (bytes memory) {
+		bytes32 ethSignedMessageHash = toEthSignedMessageHash(messageHash);
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedMessageHash);
+		return abi.encodePacked(r, s, v);
+	}
+
+	function createSessionRequestHash(
+		address provider,
+		address sessionOwner,
+		bytes32 sessionSalt,
+		uint48 expiry
+	) private pure returns (bytes32) {
+		return keccak256(abi.encodePacked(provider, sessionOwner, sessionSalt, expiry));
+	}
+
+	function createSessionHash(bytes32 sessionRequestHash, bytes32 challengeHash) private pure returns (bytes32) {
+		return keccak256(abi.encodePacked(sessionRequestHash, challengeHash));
+	}
+
+	function setupNewSafe() private returns (address, uint256) {
+		uint256 newOwnerPrivateKey = uint256(keccak256(abi.encodePacked("deterministic_salt", block.number)));
+		address newOwner = vm.addr(newOwnerPrivateKey);
+		address newSafe = twoFAFactory.getAddress(newOwner, 0);
+		upgradeableCommunityTokenScript.mint(newSafe, 100000000);
+		return (newSafe, newOwnerPrivateKey);
+	}
+
+	function createUserOperation(
+		address _safe,
+		bytes memory initCode,
+		address destination,
+		bytes memory transferData
+	) private view returns (UserOperation memory) {
+		bytes memory callData = abi.encodeWithSelector(
+			ModuleManager.execTransactionFromModule.selector,
+			destination,
+			0,
+			transferData,
+			Enum.Operation.Call
+		);
+
+		return
+			UserOperation({
+				sender: _safe,
+				nonce: getNonce(_safe, 0),
+				initCode: initCode,
+				callData: callData,
+				callGasLimit: 100000,
+				verificationGasLimit: 100000,
+				preVerificationGas: 100000,
+				maxFeePerGas: 100000000000000000,
+				maxPriorityFeePerGas: 100000000000000000,
+				paymasterAndData: bytes(""),
+				signature: bytes("")
+			});
+	}
+
+	function executeUserOp(UserOperation memory userOp) private {
+		UserOperation[] memory userOperations = new UserOperation[](1);
+		userOperations[0] = userOp;
+
+		vm.startBroadcast(ownerPrivateKey);
+		communityModule.handleOps(userOperations, payable(owner));
+		vm.stopBroadcast();
+	}
+
+	function signUserOp(
+		UserOperation memory userOp,
+		uint256 newOwnerPrivateKey
+	) private view returns (bytes memory, bytes memory) {
+		uint48 validUntil = uint48(block.timestamp + 1 hours);
+		uint48 validAfter = uint48(block.timestamp);
+
+		bytes32 paymasterHash = toEthSignedMessageHash(paymaster.getHash(userOp, validUntil, validAfter));
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, paymasterHash);
+		bytes memory paymasterAndData = constructPaymasterAndData(validUntil, validAfter, abi.encodePacked(r, s, v));
+
+		userOp.paymasterAndData = paymasterAndData;
+
+		bytes32 userOperationHash = toEthSignedMessageHash(communityModule.getUserOpHash(userOp));
+		(v, r, s) = vm.sign(newOwnerPrivateKey, userOperationHash);
+		bytes memory signature = abi.encodePacked(r, s, v);
+
+		return (paymasterAndData, signature);
+	}
+
+	function constructPaymasterAndData(
+		uint48 validUntil,
+		uint48 validAfter,
+		bytes memory signature
+	) public view returns (bytes memory) {
+		return abi.encodePacked(address(paymaster), abi.encode(validUntil, validAfter), signature);
+	}
+
+	function getNonce(address sender, uint192 key) internal view returns (uint256) {
+		address entryPoint = vm.envAddress("ERC4337_ENTRYPOINT");
+
+		return INonceManager(payable(entryPoint)).getNonce(sender, key);
+	}
+
+	function generateInitCode(address factoryAddress, address _owner, uint256 salt) public pure returns (bytes memory) {
+		// Define the function selector for the createAccount function
+		bytes4 functionSelector = bytes4(keccak256("createAccount(address,uint256)"));
+
+		// Encode the calldata for the factory function
+		bytes memory calldataEncoded = abi.encodeWithSelector(functionSelector, _owner, salt);
+
+		// Concatenate the factory address and the calldata
+		bytes memory initCode = abi.encodePacked(factoryAddress, calldataEncoded);
+
+		return initCode;
+	}
+
+	function isAnvil() private view returns (bool) {
+		return block.chainid == 31_337;
+	}
+}


### PR DESCRIPTION
- request to become a temporary signer on a safe
- request handled through a 2 factor provider
- hash a 2 factor salt `phone_number:sms` and receive a deterministic safe address (this means we can turn phone numbers and emails into safes)
- add a guard that will remove expired signers from the safe before executing a transaction
- add support for the guard in the community module

Session Management:
- main module: `src/Modules/Session/SessionManagerModule.sol`
- account factory: `src/Modules/Session/TwoFAFactory.sol`
- test: `test/SessionManagerModule.t.sol`