### PR TITLE
Add OnRampSwapper Contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/
 
 
 .dart_tool/
+lcov.info

--- a/README.md
+++ b/README.md
@@ -128,5 +128,5 @@ $ forge script script/upgrade/UpgradeSessionManagerModule.s.sol:UpgradeSessionMa
 ```shell
 $ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address)" 0xCB9bD5aCD627e8FcCf9EB8d4ba72AEb1Cd8Ff5EF 0x14196F08a4Fa0B66B7331bC40dd6bCd8A1dEeA9F 0x2d900678a66df705D3F3184267eAf603d809d3c4 --rpc-url $POLYGON_AMOY_RPC_URL --etherscan-api-key $POLYGON_AMOY_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_AMOY_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 
-$ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address)" 0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359 0xaaCE2863AdB64c1c66c83Ae6a95EB41463B43628 --rpc-url $POLYGON_RPC_URL --etherscan-api-key $POLYGON_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+$ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address,address)" 0xf5b509bB0909a69B1c207E495f687a596C168E12 0x0D9B0790E97e3426C161580dF4Ee853E4A7C4607 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 0xA232F16aB37C9a646f91Ba901E92Ed1Ba4B7b544  --rpc-url $POLYGON_RPC_URL --etherscan-api-key $POLYGON_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/README.md
+++ b/README.md
@@ -123,3 +123,8 @@ $ forge script script/SessionManagerModule.s.sol:SessionManagerModuleScript --si
 ```shell
 $ forge script script/upgrade/UpgradeSessionManagerModule.s.sol:UpgradeSessionManagerModuleScript --sig "run(address)" "0xE544c1dC66f65967863F03AEdEd38944E6b87309" --rpc-url $GNOSIS_MAINNET_RPC_URL --etherscan-api-key $GNOSIS_MAINNET_ETHERSCAN_API_KEY --verify --verifier-url $GNOSIS_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```
+
+# Swapper
+```shell
+$ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address)" 0xCB9bD5aCD627e8FcCf9EB8d4ba72AEb1Cd8Ff5EF 0x14196F08a4Fa0B66B7331bC40dd6bCd8A1dEeA9F 0x2d900678a66df705D3F3184267eAf603d809d3c4 --rpc-url $POLYGON_AMOY_RPC_URL --etherscan-api-key $POLYGON_AMOY_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_AMOY_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+```

--- a/README.md
+++ b/README.md
@@ -127,4 +127,6 @@ $ forge script script/upgrade/UpgradeSessionManagerModule.s.sol:UpgradeSessionMa
 # Swapper
 ```shell
 $ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address)" 0xCB9bD5aCD627e8FcCf9EB8d4ba72AEb1Cd8Ff5EF 0x14196F08a4Fa0B66B7331bC40dd6bCd8A1dEeA9F 0x2d900678a66df705D3F3184267eAf603d809d3c4 --rpc-url $POLYGON_AMOY_RPC_URL --etherscan-api-key $POLYGON_AMOY_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_AMOY_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
+
+$ forge script script/OnRampSwapper.s.sol:OnRampSwapperScript --sig "deploy(address,address,address)" 0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359 0xaaCE2863AdB64c1c66c83Ae6a95EB41463B43628 --rpc-url $POLYGON_RPC_URL --etherscan-api-key $POLYGON_ETHERSCAN_API_KEY --verify --verifier-url $POLYGON_ETHERSCAN_VERIFIER_URL --private-key $PRIVATE_KEY 
 ```

--- a/lib/abi/IUniswapV2Router02.json
+++ b/lib/abi/IUniswapV2Router02.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "function",
+    "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+    "inputs": [
+      {
+        "name": "amountOutMin",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "path",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  }
+]

--- a/lib/abi/OnRampSwapper.json
+++ b/lib/abi/OnRampSwapper.json
@@ -1,0 +1,221 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_quickswapRouter",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_ctznToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_treasuryAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "ctznToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "emergencyWithdraw",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "onRampAndSwap",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountOutMin",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quickswapRouter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "treasuryAddress",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updateTreasuryAddress",
+    "inputs": [
+      {
+        "name": "_newTreasury",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SwapExecuted",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amountPOL",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountCTZN",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TreasuryAddressUpdated",
+    "inputs": [
+      {
+        "name": "newTreasury",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  }
+]

--- a/script/OnRampSwapper.s.sol
+++ b/script/OnRampSwapper.s.sol
@@ -6,12 +6,12 @@ import { Script, console } from "forge-std/Script.sol";
 import { OnRampSwapper } from "../src/OnRampProvider/OnRampSwapper.sol";
 
 contract OnRampSwapperScript is Script {
-	function deploy(address _quickswapRouter, address _ctznToken, address _wmatic,  address _treasuryAddress) public {
+	function deploy(address _quickswapRouter, address _ctznToken, address _wpol,  address _treasuryAddress) public {
 		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
 		address deployerAddress = vm.envAddress("ACCOUNT_ADDRESS");
 		vm.startBroadcast(deployerPrivateKey);
 
-		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _wmatic, _treasuryAddress));
+		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _wpol, _treasuryAddress));
 
 		console.logAddress(implementation);
 

--- a/script/OnRampSwapper.s.sol
+++ b/script/OnRampSwapper.s.sol
@@ -6,12 +6,12 @@ import { Script, console } from "forge-std/Script.sol";
 import { OnRampSwapper } from "../src/OnRampProvider/OnRampSwapper.sol";
 
 contract OnRampSwapperScript is Script {
-	function deploy(address _quickswapRouter, address _ctznToken, address _treasuryAddress) public {
+	function deploy(address _quickswapRouter, address _ctznToken, address _treasuryAddress, address _wmatic) public {
 		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
 		address deployerAddress = vm.envAddress("ACCOUNT_ADDRESS");
 		vm.startBroadcast(deployerPrivateKey);
 
-		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _treasuryAddress));
+		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _treasuryAddress, _wmatic));
 
 		console.logAddress(implementation);
 

--- a/script/OnRampSwapper.s.sol
+++ b/script/OnRampSwapper.s.sol
@@ -6,12 +6,12 @@ import { Script, console } from "forge-std/Script.sol";
 import { OnRampSwapper } from "../src/OnRampProvider/OnRampSwapper.sol";
 
 contract OnRampSwapperScript is Script {
-	function deploy(address _quickswapRouter, address _ctznToken, address _treasuryAddress, address _wmatic) public {
+	function deploy(address _quickswapRouter, address _ctznToken, address _wmatic,  address _treasuryAddress) public {
 		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
 		address deployerAddress = vm.envAddress("ACCOUNT_ADDRESS");
 		vm.startBroadcast(deployerPrivateKey);
 
-		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _treasuryAddress, _wmatic));
+		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _wmatic, _treasuryAddress));
 
 		console.logAddress(implementation);
 

--- a/script/OnRampSwapper.s.sol
+++ b/script/OnRampSwapper.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { Script, console } from "forge-std/Script.sol";
+
+import { OnRampSwapper } from "../src/OnRampProvider/OnRampSwapper.sol";
+
+contract OnRampSwapperScript is Script {
+	function deploy(address _quickswapRouter, address _ctznToken, address _treasuryAddress) public {
+		uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+		address deployerAddress = vm.envAddress("ACCOUNT_ADDRESS");
+		vm.startBroadcast(deployerPrivateKey);
+
+		address implementation = address(new OnRampSwapper(_quickswapRouter, _ctznToken, _treasuryAddress));
+
+		console.logAddress(implementation);
+
+		vm.stopBroadcast();
+	}
+}

--- a/src/OnRampProvider/IUniswapV2Router02.sol
+++ b/src/OnRampProvider/IUniswapV2Router02.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IUniswapV2Router02 {
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+}

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -19,7 +19,7 @@ interface ISwapRouter {
     function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
 }
 
-interface IWMATIC {
+interface IWPOL {
     function deposit() external payable;
     function approve(address spender, uint256 amount) external returns (bool);
 }
@@ -27,7 +27,7 @@ interface IWMATIC {
 contract OnRampSwapper is Ownable, ReentrancyGuard {
     address public immutable quickswapRouter;
     address public immutable ctznToken;
-    address public immutable wmatic;
+    address public immutable wpol;
     address public treasuryAddress;
 
     event SwapExecuted(address indexed recipient, uint256 amountPOL, uint256 amountCTZN);
@@ -36,17 +36,17 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
     constructor(
         address _swapRouter,
         address _ctznToken,
-        address _wmatic,
+        address _wpol,
         address _treasuryAddress
     ) Ownable(msg.sender) {
         require(_swapRouter != address(0), "Invalid router address");
         require(_ctznToken != address(0), "Invalid CTZN address");
-        require(_wmatic != address(0), "Invalid WMATIC address");
+        require(_wpol != address(0), "Invalid WPOL address");
         require(_treasuryAddress != address(0), "Invalid treasury address");
 
         quickswapRouter = _swapRouter;
         ctznToken = _ctznToken;
-        wmatic = _wmatic;
+        wpol = _wpol;
         treasuryAddress = _treasuryAddress;
     }
 
@@ -56,11 +56,11 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 
         uint256 amountPOL = msg.value;
 
-        IWMATIC(wmatic).deposit{value: amountPOL}();
-        require(IWMATIC(wmatic).approve(quickswapRouter, amountPOL), "Approve failed");
+        IWPOL(wpol).deposit{value: amountPOL}();
+        require(IWPOL(wpol).approve(quickswapRouter, amountPOL), "Approve failed");
 
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
-            tokenIn: wmatic,
+            tokenIn: wpol,
             tokenOut: ctznToken,
             recipient: recipient,
             deadline: block.timestamp + 600,

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./IUniswapV2Router02.sol";
+
+contract OnRampSwapper is Ownable, ReentrancyGuard {
+    address public quickswapRouter;
+    address public ctznToken;
+    address public treasuryAddress;
+
+    event SwapExecuted(address indexed recipient, uint256 amountPOL, uint256 amountCTZN);
+    event TreasuryAddressUpdated(address indexed newTreasury);
+
+    constructor(address _quickswapRouter, address _ctznToken, address _treasuryAddress) Ownable(msg.sender) {
+        require(_quickswapRouter != address(0), "Invalid router address");
+        require(_ctznToken != address(0), "Invalid CTZN address");
+        require(_treasuryAddress != address(0), "Invalid treasury address");
+
+        quickswapRouter = _quickswapRouter;
+        ctznToken = _ctznToken;
+        treasuryAddress = _treasuryAddress;
+    }
+
+    // Function called by Transak after fiat payment is complete
+    function onRampAndSwap(address recipient, uint256 amountOutMin) external payable nonReentrant {
+        require(msg.value > 0, "No POL sent");
+        require(recipient != address(0), "Invalid recipient address");
+
+        uint256 amountPOL = msg.value;
+
+        address[] memory path = new address[](2);
+        path[0] = 0x0000000000000000000000000000000000001010; // Native POL (MATIC)
+        path[1] = ctznToken;
+
+        IUniswapV2Router02(quickswapRouter).swapExactETHForTokensSupportingFeeOnTransferTokens{ value: amountPOL }(
+            amountOutMin,
+            path,
+            recipient,
+            block.timestamp + 10 minutes
+        );
+
+        // If any excess POL left in the contract (shouldn't normally happen), send to treasury
+        uint256 excessPOL = address(this).balance;
+        if (excessPOL > 0) {
+            (bool success, ) = treasuryAddress.call{ value: excessPOL }("");
+            require(success, "Sending excess POL failed");
+        }
+
+        emit SwapExecuted(recipient, amountPOL, IERC20(ctznToken).balanceOf(recipient));
+    }
+
+    // Owner can update treasury address
+    function updateTreasuryAddress(address _newTreasury) external onlyOwner {
+        require(_newTreasury != address(0), "Invalid treasury address");
+        treasuryAddress = _newTreasury;
+        emit TreasuryAddressUpdated(_newTreasury);
+    }
+
+    // Emergency: owner can withdraw stuck POL
+    function emergencyWithdraw() external onlyOwner {
+        uint256 balance = address(this).balance;
+        require(balance > 0, "No POL to withdraw");
+        (bool success, ) = owner().call{ value: balance }("");
+        require(success, "Withdraw failed");
+    }
+
+    receive() external payable {}
+}

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -4,27 +4,44 @@ pragma solidity ^0.8.20;
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/// @title QuickSwap Router Interface
+/// @notice Interface for interacting with QuickSwap's router contract
 interface ISwapRouter {
+	/// @notice Parameters for exact input single token swap
 	struct ExactInputSingleParams {
-		address tokenIn;
-		address tokenOut;
-		address recipient;
-		uint256 deadline;
-		uint256 amountIn;
-		uint256 amountOutMinimum;
-		uint160 sqrtPriceLimitX96;
+		address tokenIn;           // Address of input token
+		address tokenOut;          // Address of output token
+		address recipient;         // Address to receive output tokens
+		uint256 deadline;          // Unix timestamp deadline for the swap
+		uint256 amountIn;          // Amount of input tokens to send
+		uint256 amountOutMinimum;  // Minimum amount of output tokens to receive
+		uint160 sqrtPriceLimitX96; // Price limit for the swap (0 for no limit)
 	}
 
+	/// @notice Executes a swap with exact input amount
+	/// @param params The parameters for the swap
+	/// @return amountOut The amount of output tokens received
 	function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
 }
 
+/// @title Wrapped POL Interface
+/// @notice Interface for interacting with the Wrapped POL token contract
 interface IWPOL {
+	/// @notice Wraps POL by depositing it into the contract
 	function deposit() external payable;
+	
+	/// @notice Approves the spender to spend tokens
+	/// @param spender Address to approve
+	/// @param amount Amount to approve
+	/// @return success Whether the approval was successful
 	function approve(address spender, uint256 amount) external returns (bool);
 }
 
+/// @title OnRampSwapper
+/// @notice Contract for swapping POL to CTZN tokens through QuickSwap
+/// @dev Implements reentrancy protection and safe approval patterns
 contract OnRampSwapper is Ownable, ReentrancyGuard {
-	// Custom errors
+	// Custom errors for better gas efficiency and error handling
 	error InvalidRouterAddress();
 	error InvalidCTZNAddress();
 	error InvalidWPOLAddress();
@@ -37,15 +54,22 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 	error WithdrawFailed();
 	error InsufficientOutputAmount(uint256 actualAmount, uint256 minimumAmount);
 
-	address public immutable QUICKSWAP_ROUTER;
-	address public immutable CTZN_TOKEN;
-	address public immutable WPOL;
-	address public treasuryAddress;
+	// Immutable state variables
+	address public immutable QUICKSWAP_ROUTER;  // QuickSwap router address
+	address public immutable CTZN_TOKEN;        // CTZN token address
+	address public immutable WPOL;              // Wrapped POL token address
+	address public treasuryAddress;             // Treasury address for excess POL
 
+	// Events for tracking important state changes
 	event SwapExecuted(address indexed recipient, uint256 amountPOL, uint256 amountCTZN);
 	event TreasuryAddressUpdated(address indexed newTreasury);
 	event TreasuryChanged(address indexed oldTreasury, address indexed newTreasury);
 
+	/// @notice Constructor initializes the contract with required addresses
+	/// @param _swapRouter Address of the QuickSwap router
+	/// @param _ctznToken Address of the CTZN token
+	/// @param _wpol Address of the Wrapped POL token
+	/// @param _treasuryAddress Address of the treasury
 	constructor(address _swapRouter, address _ctznToken, address _wpol, address _treasuryAddress) Ownable(msg.sender) {
 		if (_swapRouter == address(0)) revert InvalidRouterAddress();
 		if (_ctznToken == address(0)) revert InvalidCTZNAddress();
@@ -58,36 +82,45 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 		treasuryAddress = _treasuryAddress;
 	}
 
+	/// @notice Swaps POL to CTZN tokens
+	/// @dev Implements reentrancy protection and safe approval pattern
+	/// @param recipient Address to receive the CTZN tokens
+	/// @param amountOutMin Minimum amount of CTZN tokens to receive
 	function onRampAndSwap(address recipient, uint256 amountOutMin) external payable nonReentrant {
 		if (msg.value == 0) revert NoPOLSent();
 		if (recipient == address(0)) revert InvalidRecipientAddress();
 
 		uint256 amountPOL = msg.value;
 
+		// 1. Wrap POL to WPOL
 		IWPOL(WPOL).deposit{ value: amountPOL }();
+		
+		// 2. Approve router to spend WPOL
 		if (!IWPOL(WPOL).approve(QUICKSWAP_ROUTER, amountPOL)) revert ApproveFailed();
 
+		// 3. Prepare swap parameters
 		ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
 			tokenIn: WPOL,
 			tokenOut: CTZN_TOKEN,
 			recipient: recipient,
-			deadline: block.timestamp + 600,
+			deadline: block.timestamp + 600, // 10-minute deadline
 			amountIn: amountPOL,
 			amountOutMinimum: amountOutMin,
 			sqrtPriceLimitX96: 0
 		});
 
+		// 4. Reset approval to 0 for security
+		if (!IWPOL(WPOL).approve(QUICKSWAP_ROUTER, 0)) revert ApproveFailed();
+
+		// 5. Execute swap
 		uint256 amountOut = ISwapRouter(QUICKSWAP_ROUTER).exactInputSingle(params);
 		
-		// Add slippage protection check
+		// 6. Verify slippage
 		if (amountOut < amountOutMin) revert InsufficientOutputAmount(amountOut, amountOutMin);
-		
-		// Reset approval to 0 after swap
-		if (!IWPOL(WPOL).approve(QUICKSWAP_ROUTER, 0)) revert ApproveFailed();
 		
 		emit SwapExecuted(recipient, amountPOL, amountOut);
 
-		// Calculate excess after the swap is completed
+		// 7. Send any excess POL to treasury
 		uint256 excess = address(this).balance;
 		if (excess > 0) {
 			(bool success, ) = treasuryAddress.call{ value: excess }("");
@@ -95,6 +128,9 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 		}
 	}
 
+	/// @notice Updates the treasury address
+	/// @dev Only callable by owner
+	/// @param _newTreasury New treasury address
 	function updateTreasuryAddress(address _newTreasury) external onlyOwner {
 		if (_newTreasury == address(0)) revert InvalidTreasuryAddress();
 		address oldTreasury = treasuryAddress;
@@ -103,6 +139,8 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 		emit TreasuryChanged(oldTreasury, _newTreasury);
 	}
 
+	/// @notice Emergency function to withdraw stuck POL
+	/// @dev Only callable by owner
 	function emergencyWithdraw() external onlyOwner {
 		uint256 balance = address(this).balance;
 		if (balance == 0) revert NoPOLToWithdraw();
@@ -110,5 +148,7 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
 		if (!success) revert WithdrawFailed();
 	}
 
+	/// @notice Receive function to accept POL
+	/// @dev Implements reentrancy protection
 	receive() external payable nonReentrant {}
 }

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -9,7 +9,6 @@ interface ISwapRouter {
     struct ExactInputSingleParams {
         address tokenIn;
         address tokenOut;
-        uint24 fee;
         address recipient;
         uint256 deadline;
         uint256 amountIn;
@@ -63,7 +62,6 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: wmatic,
             tokenOut: ctznToken,
-            fee: 3000,
             recipient: recipient,
             deadline: block.timestamp + 600,
             amountIn: amountPOL,

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -4,66 +4,93 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IUniswapV2Router02.sol";
+
+interface ISwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+}
+
+interface IWMATIC {
+    function deposit() external payable;
+    function approve(address spender, uint256 amount) external returns (bool);
+}
 
 contract OnRampSwapper is Ownable, ReentrancyGuard {
-    address public quickswapRouter;
-    address public ctznToken;
+    address public immutable quickswapRouter;
+    address public immutable ctznToken;
+    address public immutable wmatic;
     address public treasuryAddress;
 
     event SwapExecuted(address indexed recipient, uint256 amountPOL, uint256 amountCTZN);
     event TreasuryAddressUpdated(address indexed newTreasury);
 
-    constructor(address _quickswapRouter, address _ctznToken, address _treasuryAddress) Ownable(msg.sender) {
-        require(_quickswapRouter != address(0), "Invalid router address");
+    constructor(
+        address _swapRouter,
+        address _ctznToken,
+        address _wmatic,
+        address _treasuryAddress
+    ) Ownable(msg.sender) {
+        require(_swapRouter != address(0), "Invalid router address");
         require(_ctznToken != address(0), "Invalid CTZN address");
+        require(_wmatic != address(0), "Invalid WMATIC address");
         require(_treasuryAddress != address(0), "Invalid treasury address");
 
-        quickswapRouter = _quickswapRouter;
+        quickswapRouter = _swapRouter;
         ctznToken = _ctznToken;
+        wmatic = _wmatic;
         treasuryAddress = _treasuryAddress;
     }
 
-    // Function called by Transak after fiat payment is complete
     function onRampAndSwap(address recipient, uint256 amountOutMin) external payable nonReentrant {
-        require(msg.value > 0, "No POL sent");
+        require(msg.value > 0, "No MATIC sent");
         require(recipient != address(0), "Invalid recipient address");
 
         uint256 amountPOL = msg.value;
 
-        address[] memory path = new address[](2);
-        path[0] = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270; //Wrapped POL (WPOL)
-        path[1] = ctznToken;
+        IWMATIC(wmatic).deposit{value: amountPOL}();
+        require(IWMATIC(wmatic).approve(quickswapRouter, amountPOL), "Approve failed");
 
-        IUniswapV2Router02(quickswapRouter).swapExactETHForTokensSupportingFeeOnTransferTokens{ value: amountPOL }(
-            amountOutMin,
-            path,
-            recipient,
-            block.timestamp + 10 minutes
-        );
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+            tokenIn: wmatic,
+            tokenOut: ctznToken,
+            fee: 3000,
+            recipient: recipient,
+            deadline: block.timestamp + 600,
+            amountIn: amountPOL,
+            amountOutMinimum: amountOutMin,
+            sqrtPriceLimitX96: 0
+        });
 
-        // If any excess POL left in the contract (shouldn't normally happen), send to treasury
-        uint256 excessPOL = address(this).balance;
-        if (excessPOL > 0) {
-            (bool success, ) = treasuryAddress.call{ value: excessPOL }("");
-            require(success, "Sending excess POL failed");
+        uint256 amountOut = ISwapRouter(quickswapRouter).exactInputSingle(params);
+        emit SwapExecuted(recipient, amountPOL, amountOut);
+
+        uint256 excess = address(this).balance;
+        if (excess > 0) {
+            (bool success, ) = treasuryAddress.call{value: excess}("");
+            require(success, "Sending excess MATIC failed");
         }
-
-        emit SwapExecuted(recipient, amountPOL, IERC20(ctznToken).balanceOf(recipient));
     }
 
-    // Owner can update treasury address
     function updateTreasuryAddress(address _newTreasury) external onlyOwner {
         require(_newTreasury != address(0), "Invalid treasury address");
         treasuryAddress = _newTreasury;
         emit TreasuryAddressUpdated(_newTreasury);
     }
 
-    // Emergency: owner can withdraw stuck POL
     function emergencyWithdraw() external onlyOwner {
         uint256 balance = address(this).balance;
-        require(balance > 0, "No POL to withdraw");
-        (bool success, ) = owner().call{ value: balance }("");
+        require(balance > 0, "No MATIC to withdraw");
+        (bool success, ) = owner().call{value: balance}("");
         require(success, "Withdraw failed");
     }
 

--- a/src/OnRampProvider/OnRampSwapper.sol
+++ b/src/OnRampProvider/OnRampSwapper.sol
@@ -32,7 +32,7 @@ contract OnRampSwapper is Ownable, ReentrancyGuard {
         uint256 amountPOL = msg.value;
 
         address[] memory path = new address[](2);
-        path[0] = 0x0000000000000000000000000000000000001010; // Native POL (MATIC)
+        path[0] = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270; //Wrapped POL (WPOL)
         path[1] = ctznToken;
 
         IUniswapV2Router02(quickswapRouter).swapExactETHForTokensSupportingFeeOnTransferTokens{ value: amountPOL }(

--- a/src/OnRampProvider/README.md
+++ b/src/OnRampProvider/README.md
@@ -1,0 +1,120 @@
+# OnRampSwapper Smart Contract
+
+## Overview
+The OnRampSwapper is a secure smart contract designed to facilitate the swapping of POL (Polygon) tokens to CTZN tokens through the QuickSwap DEX. It acts as an on-ramp service that handles the wrapping of POL to WPOL and subsequent token swaps.
+
+## Core Functionality
+1. **Token Swapping**: Converts POL to CTZN tokens through QuickSwap
+2. **POL Wrapping**: Automatically wraps POL to WPOL before swapping
+3. **Treasury Management**: Handles excess POL by sending it to a treasury address
+4. **Emergency Controls**: Includes emergency withdrawal functionality for contract owners
+
+## Security Features
+
+### 1. Access Control
+- **Ownable Pattern**: Implements OpenZeppelin's `Ownable` contract for administrative functions
+- **Restricted Functions**:
+  - `updateTreasuryAddress`: Only callable by owner
+  - `emergencyWithdraw`: Only callable by owner
+
+### 2. Reentrancy Protection
+- **ReentrancyGuard**: Implements OpenZeppelin's `ReentrancyGuard` to prevent reentrancy attacks
+- Applied to critical functions:
+  - `onRampAndSwap`
+  - `receive` function
+
+### 3. Input Validation
+- **Zero Address Checks**:
+  - Router address
+  - CTZN token address
+  - WPOL address
+  - Treasury address
+  - Recipient address
+- **Value Checks**:
+  - Ensures non-zero POL amount for swaps
+  - Validates minimum output amounts
+
+### 4. Slippage Protection
+- Implements minimum output amount parameter (`amountOutMin`)
+- Verifies actual output against minimum expected output
+- Custom error `InsufficientOutputAmount` for failed slippage checks
+
+### 5. Safe Token Approvals
+- Implements approval reset pattern:
+  1. Approves router for exact amount needed
+  2. Resets approval to zero after swap
+  3. Prevents potential approval-based attacks
+
+### 6. Error Handling
+- Custom errors for all failure cases
+- Comprehensive error messages for debugging
+
+### 7. Event Emission
+- Critical state changes are logged:
+  - `SwapExecuted`: Records swap details
+  - `TreasuryAddressUpdated`: Logs treasury changes
+  - `TreasuryChanged`: Records old and new treasury addresses
+
+### 8. Emergency Features
+- **Emergency Withdrawal**:
+  - Allows owner to withdraw stuck POL
+  - Includes balance checks
+  - Implements transfer failure handling
+
+## Usage
+
+### Constructor Parameters
+```solidity
+constructor(
+    address _swapRouter,    // QuickSwap router address
+    address _ctznToken,     // CTZN token address
+    address _wpol,          // Wrapped POL token address
+    address _treasuryAddress // Treasury address for excess POL
+)
+```
+
+### Main Functions
+1. `onRampAndSwap(address recipient, uint256 amountOutMin)`
+   - Swaps POL to CTZN tokens
+   - Requires non-zero POL value
+   - Validates minimum output amount
+
+2. `updateTreasuryAddress(address _newTreasury)`
+   - Updates treasury address
+   - Only callable by owner
+   - Emits events for tracking
+
+3. `emergencyWithdraw()`
+   - Emergency POL withdrawal
+   - Only callable by owner
+   - Includes safety checks
+
+## Security Considerations
+
+### Strengths
+1. Comprehensive input validation
+2. Reentrancy protection
+3. Safe approval pattern
+4. Slippage protection
+5. Emergency controls
+6. Extensive testing
+
+### Potential Areas for Review
+1. Deadline parameter (fixed 600-second deadline)
+2. Treasury address updates (consider timelock)
+3. WPOL approval implementation
+4. Gas optimization opportunities
+
+## Testing
+The contract includes comprehensive test coverage in `test/OnRampSwapper.t.sol`:
+- Constructor parameter validation
+- Swap functionality
+- Error cases
+- Reentrancy protection
+- Slippage protection
+- Treasury management
+- Emergency functions
+- Fuzzing tests
+
+## License
+MIT License 

--- a/test/OnRampSwapper.t.sol
+++ b/test/OnRampSwapper.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/OnRampProvider/OnRampSwapper.sol";
+import "../src/OnRampProvider/IUniswapV2Router02.sol";
+
+contract MockCTZN is IERC20 {
+    string public constant name = "CTZN";
+    string public constant symbol = "CTZN";
+    uint8 public constant decimals = 18;
+    uint256 public override totalSupply;
+
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    function transfer(address recipient, uint256 amount) external override returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[recipient] += amount;
+        return true;
+    }
+
+    function transferFrom(address sender, address recipient, uint256 amount) external override returns (bool) {
+        allowance[sender][msg.sender] -= amount;
+        balanceOf[sender] -= amount;
+        balanceOf[recipient] += amount;
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+}
+
+contract MockRouter is IUniswapV2Router02 {
+    address public ctznToken;
+
+    constructor(address _ctznToken) {
+        ctznToken = _ctznToken;
+    }
+
+    receive() external payable {}
+
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable override {
+        require(msg.value > 0, "No ETH sent");
+        require(block.timestamp <= deadline, "Deadline passed");
+
+        uint256 tokenAmount = msg.value * 1000; // Simulate rate
+
+        MockCTZN(ctznToken).mint(to, tokenAmount);
+    }
+}
+
+contract OnRampSwapperTest is Test {
+    OnRampSwapper public swapper;
+    MockCTZN public ctzn;
+    MockRouter public router;
+    address public treasury = address(0xBEEF);
+    address public user = address(0xABCD);
+
+    receive() external payable {}
+
+    function setUp() public {
+        ctzn = new MockCTZN();
+        router = new MockRouter(address(ctzn));
+        swapper = new OnRampSwapper(address(router), address(ctzn), treasury);
+        vm.deal(address(this), 100 ether);
+        vm.deal(user, 10 ether);
+    }
+
+    function testConstructorSetsValues() public {
+        assertEq(swapper.ctznToken(), address(ctzn));
+        assertEq(swapper.quickswapRouter(), address(router));
+        assertEq(swapper.treasuryAddress(), treasury);
+    }
+
+    function testOnRampAndSwap() public {
+        address recipient = address(0x1234);
+        uint256 value = 1 ether;
+
+        vm.deal(address(this), value);
+        swapper.onRampAndSwap{value: value}(recipient, 0);
+
+        uint256 balance = ctzn.balanceOf(recipient);
+        assertGt(balance, 0);
+    }
+
+    function testFailOnRampWithZeroPOL() public {
+        swapper.onRampAndSwap{value: 0}(user, 0);
+    }
+
+    function testFailOnRampWithZeroRecipient() public {
+        swapper.onRampAndSwap{value: 1 ether}(address(0), 0);
+    }
+
+    function testUpdateTreasuryAddress() public {
+        address newTreasury = address(0xD00D);
+        swapper.updateTreasuryAddress(newTreasury);
+        assertEq(swapper.treasuryAddress(), newTreasury);
+    }
+
+    function testFailUpdateTreasuryToZero() public {
+        swapper.updateTreasuryAddress(address(0));
+    }
+
+    function testEmergencyWithdraw() public {
+        vm.deal(address(swapper), 1 ether);
+        uint256 before = address(this).balance;
+
+        swapper.emergencyWithdraw();
+        assertGt(address(this).balance, before);
+    }
+
+    function testFailEmergencyWithdrawNoBalance() public {
+        swapper.emergencyWithdraw();
+    }
+
+    function testReceiveFallback() public {
+        (bool success, ) = address(swapper).call{value: 1 ether}("");
+        assertTrue(success);
+    }
+
+    function testFuzz_onRampAndSwap(uint256 ethAmount) public {
+        ethAmount = bound(ethAmount, 1e15, 1 ether); // Bound for realistic fuzzing
+        vm.deal(address(this), ethAmount);
+
+        swapper.onRampAndSwap{value: ethAmount}(user, 0);
+        assertGt(ctzn.balanceOf(user), 0);
+    }
+}

--- a/test/OnRampSwapper.t.sol
+++ b/test/OnRampSwapper.t.sol
@@ -4,194 +4,264 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 import "../src/OnRampProvider/OnRampSwapper.sol";
 import "../src/OnRampProvider/IUniswapV2Router02.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract MockCTZN is IERC20 {
-    string public constant name = "CTZN";
-    string public constant symbol = "CTZN";
-    uint8 public constant decimals = 18;
-    uint256 public override totalSupply;
+	string public constant name = "CTZN";
+	string public constant symbol = "CTZN";
+	uint8 public constant decimals = 18;
+	uint256 public override totalSupply;
 
-    mapping(address => uint256) public override balanceOf;
-    mapping(address => mapping(address => uint256)) public override allowance;
+	mapping(address => uint256) public override balanceOf;
+	mapping(address => mapping(address => uint256)) public override allowance;
 
-    function transfer(address recipient, uint256 amount) external override returns (bool) {
-        balanceOf[msg.sender] -= amount;
-        balanceOf[recipient] += amount;
-        return true;
-    }
+	function transfer(address recipient, uint256 amount) external override returns (bool) {
+		balanceOf[msg.sender] -= amount;
+		balanceOf[recipient] += amount;
+		return true;
+	}
 
-    function transferFrom(address sender, address recipient, uint256 amount) external override returns (bool) {
-        allowance[sender][msg.sender] -= amount;
-        balanceOf[sender] -= amount;
-        balanceOf[recipient] += amount;
-        return true;
-    }
+	function transferFrom(address sender, address recipient, uint256 amount) external override returns (bool) {
+		allowance[sender][msg.sender] -= amount;
+		balanceOf[sender] -= amount;
+		balanceOf[recipient] += amount;
+		return true;
+	}
 
-    function approve(address spender, uint256 amount) external override returns (bool) {
-        allowance[msg.sender][spender] = amount;
-        return true;
-    }
+	function approve(address spender, uint256 amount) external override returns (bool) {
+		allowance[msg.sender][spender] = amount;
+		return true;
+	}
 
-    function mint(address to, uint256 amount) external {
-        balanceOf[to] += amount;
-        totalSupply += amount;
-    }
+	function mint(address to, uint256 amount) external {
+		balanceOf[to] += amount;
+		totalSupply += amount;
+	}
 }
 
 contract MockRouter is ISwapRouter {
-    address public tokenOut;
+	address public tokenOut;
+	address public callbackTarget;
 
-    constructor(address _tokenOut) {
-        tokenOut = _tokenOut;
-    }
-    receive() external payable {}
-    function exactInputSingle(ExactInputSingleParams calldata params) external payable override returns (uint256) {
-        console.log("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
-        // Mint some CTZN to simulate swap output
-        uint256 output = params.amountIn * 2; // simulate 1 MATIC = 2 CTZN
-        MockCTZN(tokenOut).mint(params.recipient, output);
-        return output;
-    }
+	constructor(address _tokenOut) {
+		tokenOut = _tokenOut;
+	}
+
+	function setCallback(address _target) external {
+		callbackTarget = _target;
+	}
+
+	receive() external payable {}
+	function exactInputSingle(ExactInputSingleParams calldata params) external payable override returns (uint256) {
+		console.log("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+		// Mint some CTZN to simulate swap output
+		uint256 output = params.amountIn * 2; // simulate 1 MATIC = 2 CTZN
+		MockCTZN(tokenOut).mint(params.recipient, output);
+
+		// Call back to the target if set
+		if (callbackTarget != address(0)) {
+			MaliciousReentrant(callbackTarget).onERC20Received();
+		}
+
+		return output;
+	}
 }
 
-
 contract NonPayableFallback {
-    fallback() external {}
+	fallback() external {}
 }
 
 contract RevertingReceiver {
-    fallback() external payable {
-        revert("I don't accept ETH");
-    }
+	fallback() external payable {
+		revert("I don't accept ETH");
+	}
 }
 
-contract MockWMATIC is IWMATIC {
-    receive() external payable {}
+contract MockWPOL is IWPOL {
+	receive() external payable {}
 
-    function deposit() external payable override {}
+	function deposit() external payable override {}
 
-    function approve(address, uint256) external pure override returns (bool) {
-        return true;
-    }
+	function approve(address, uint256) external pure override returns (bool) {
+		return true;
+	}
+}
+
+contract MaliciousReentrant {
+	OnRampSwapper public swapper;
+	address public user;
+
+	constructor(address payable _swapper, address _user) {
+		swapper = OnRampSwapper(_swapper);
+		user = _user;
+	}
+
+	function onERC20Received() external {
+		// Attempt to reenter the swap function
+		swapper.onRampAndSwap{value: 1 ether}(user, 0);
+	}
 }
 
 contract OnRampSwapperTest is Test {
-    OnRampSwapper public swapper;
-    MockCTZN public ctzn;
-    MockRouter public router;
-    address public treasury = address(0xBEEF);
-    address public user = address(0xABCD);
-    MockWMATIC public wmatic;
+	OnRampSwapper public swapper;
+	MockCTZN public ctzn;
+	MockRouter public router;
+	address public treasury = address(0xBEEF);
+	address public user = address(0xABCD);
+	MockWPOL public wmatic;
 
-    receive() external payable {}
+	receive() external payable {}
 
-    function setUp() public {
-        ctzn = new MockCTZN();
-        router = new MockRouter(address(ctzn));
-        wmatic = new MockWMATIC();
-        swapper = new OnRampSwapper(address(router), address(ctzn), address(wmatic), treasury);
-        vm.deal(address(this), 100 ether);
-        vm.deal(user, 10 ether);
-    }
+	function setUp() public {
+		ctzn = new MockCTZN();
+		router = new MockRouter(address(ctzn));
+		wmatic = new MockWPOL();
+		swapper = new OnRampSwapper(address(router), address(ctzn), address(wmatic), treasury);
+		vm.deal(address(this), 100 ether);
+		vm.deal(user, 10 ether);
+	}
 
-    function testConstructorSetsValues() public {
-        assertEq(swapper.ctznToken(), address(ctzn));
-        assertEq(swapper.quickswapRouter(), address(router));
-        assertEq(swapper.treasuryAddress(), treasury);
-        assertEq(swapper.wmatic(), address(wmatic));
-    }
-    function testOnRampAndSwap() public {
-        address recipient = address(0x1234);
-        uint256 value = 1 ether;
+	function testConstructorSetsValues() public {
+		assertEq(swapper.CTZN_TOKEN(), address(ctzn));
+		assertEq(swapper.QUICKSWAP_ROUTER(), address(router));
+		assertEq(swapper.treasuryAddress(), treasury);
+		assertEq(swapper.WPOL(), address(wmatic));
+	}
+	function testOnRampAndSwap() public {
+		address recipient = address(0x1234);
+		uint256 value = 1 ether;
 
-        vm.deal(address(this), value);
-        swapper.onRampAndSwap{value: value}(recipient, 0);
+		vm.deal(address(this), value);
+		swapper.onRampAndSwap{ value: value }(recipient, 0);
 
-        uint256 balance = ctzn.balanceOf(recipient);
-        assertGt(balance, 0);
-    }
+		uint256 balance = ctzn.balanceOf(recipient);
+		assertGt(balance, 0);
+	}
 
-    function testFailOnRampWithZeroPOL() public {
-        swapper.onRampAndSwap{value: 0}(user, 0);
-    }
+	function test_RevertWhen_OnRampWithZeroPOL() public {
+		vm.expectRevert(OnRampSwapper.NoPOLSent.selector);
+		swapper.onRampAndSwap{ value: 0 }(user, 0);
+	}
 
-    function testFailOnRampWithZeroRecipient() public {
-        swapper.onRampAndSwap{value: 1 ether}(address(0), 0);
-    }
+	function test_RevertWhen_OnRampWithZeroRecipient() public {
+		vm.expectRevert(OnRampSwapper.InvalidRecipientAddress.selector);
+		swapper.onRampAndSwap{ value: 1 ether }(address(0), 0);
+	}
 
-    function testUpdateTreasuryAddress() public {
-        address newTreasury = address(0xD00D);
-        swapper.updateTreasuryAddress(newTreasury);
-        assertEq(swapper.treasuryAddress(), newTreasury);
-    }
+	function test_RevertWhen_UpdateTreasuryToZero() public {
+		vm.expectRevert(OnRampSwapper.InvalidTreasuryAddress.selector);
+		swapper.updateTreasuryAddress(address(0));
+	}
 
-    function testFailUpdateTreasuryToZero() public {
-        swapper.updateTreasuryAddress(address(0));
-    }
+	function test_RevertWhen_EmergencyWithdrawNoBalance() public {
+		vm.expectRevert(OnRampSwapper.NoPOLToWithdraw.selector);
+		swapper.emergencyWithdraw();
+	}
 
-    function testEmergencyWithdraw() public {
-        vm.deal(address(swapper), 1 ether);
-        uint256 before = address(this).balance;
+	function test_RevertWhen_ConstructorZeroRouter() public {
+		vm.expectRevert(OnRampSwapper.InvalidRouterAddress.selector);
+		new OnRampSwapper(address(0), address(ctzn), address(wmatic), treasury);
+	}
 
-        swapper.emergencyWithdraw();
-        assertGt(address(this).balance, before);
-    }
+	function test_RevertWhen_ConstructorZeroCTZN() public {
+		vm.expectRevert(OnRampSwapper.InvalidCTZNAddress.selector);
+		new OnRampSwapper(address(router), address(0), address(wmatic), treasury);
+	}
 
-    function testFailEmergencyWithdrawNoBalance() public {
-        swapper.emergencyWithdraw();
-    }
-    
-    function testFailConstructorZeroRouter() public {
-    new OnRampSwapper(address(0), address(ctzn), address(wmatic), treasury);
-    }
+	function test_RevertWhen_ConstructorZeroTreasury() public {
+		vm.expectRevert(OnRampSwapper.InvalidTreasuryAddress.selector);
+		new OnRampSwapper(address(router), address(ctzn), address(wmatic), address(0));
+	}
 
-    function testFailConstructorZeroCTZN() public {
-        new OnRampSwapper(address(router), address(0), address(wmatic), treasury);
-    }
+	function test_RevertWhen_OnRampAndSwapExcessPOLSendFails() public {
+		NonPayableFallback nonPayable = new NonPayableFallback();
+		swapper.updateTreasuryAddress(address(nonPayable));
 
-    function testFailConstructorZeroTreasury() public {
-        new OnRampSwapper(address(router), address(ctzn), address(wmatic), address(0));
-    }
+		vm.deal(address(swapper), 1 ether);
+		vm.deal(address(this), 1 ether);
+		vm.expectRevert(OnRampSwapper.SendingExcessPOLFailed.selector);
+		swapper.onRampAndSwap{ value: 1 ether }(user, 0);
+	}
 
+	function test_RevertWhen_EmergencyWithdrawFailsIfTransferFails() public {
+		RevertingReceiver badOwner = new RevertingReceiver();
+		swapper.transferOwnership(address(badOwner));
 
-    function testReceiveFallback() public {
-        (bool success, ) = address(swapper).call{value: 1 ether}("");
-        assertTrue(success);
-    }
+		vm.deal(address(swapper), 1 ether);
 
-    function testFuzz_onRampAndSwap(uint256 ethAmount) public {
-        ethAmount = bound(ethAmount, 1e15, 1 ether); // Bound for realistic fuzzing
-        vm.deal(address(this), ethAmount);
+		vm.prank(address(badOwner));
+		vm.expectRevert(OnRampSwapper.WithdrawFailed.selector);
+		swapper.emergencyWithdraw();
+	}
 
-        swapper.onRampAndSwap{value: ethAmount}(user, 0);
-        assertGt(ctzn.balanceOf(user), 0);
-    }
+	function testUpdateTreasuryAddress() public {
+		address newTreasury = address(0xD00D);
+		swapper.updateTreasuryAddress(newTreasury);
+		assertEq(swapper.treasuryAddress(), newTreasury);
+	}
 
-    function testOnRampAndSwapExcessPOLSentToTreasury() public {
-        // Send some ETH to the contract before calling swap to simulate excess POL
-        vm.deal(address(swapper), 1 ether);
+	function testEmergencyWithdraw() public {
+		vm.deal(address(swapper), 1 ether);
+		uint256 before = address(this).balance;
 
-        vm.deal(address(this), 1 ether);
-        swapper.onRampAndSwap{value: 1 ether}(user, 0);
-        // No revert means success, excess was sent
-    }
+		swapper.emergencyWithdraw();
+		assertGt(address(this).balance, before);
+	}
 
-    function testFailOnRampAndSwapExcessPOLSendFails() public {
-        NonPayableFallback nonPayable = new NonPayableFallback();
-        swapper.updateTreasuryAddress(address(nonPayable));
+	function testReceiveFallback() public {
+		(bool success, ) = address(swapper).call{ value: 1 ether }("");
+		assertTrue(success);
+	}
 
-        vm.deal(address(swapper), 1 ether);
-        vm.deal(address(this), 1 ether);
-        swapper.onRampAndSwap{value: 1 ether}(user, 0);
-    }
+	function testFuzz_onRampAndSwap(uint256 ethAmount) public {
+		ethAmount = bound(ethAmount, 1e15, 1 ether); // Bound for realistic fuzzing
+		vm.deal(address(this), ethAmount);
 
-    function testFailEmergencyWithdrawFailsIfTransferFails() public {
-        RevertingReceiver badOwner = new RevertingReceiver();
-        swapper.transferOwnership(address(badOwner));
+		swapper.onRampAndSwap{ value: ethAmount }(user, 0);
+		assertGt(ctzn.balanceOf(user), 0);
+	}
 
-        vm.deal(address(swapper), 1 ether);
+	function testOnRampAndSwapExcessPOLSentToTreasury() public {
+		// Send some ETH to the contract before calling swap to simulate excess POL
+		vm.deal(address(swapper), 1 ether);
 
-        vm.prank(address(badOwner));
-        swapper.emergencyWithdraw();
-    }
+		vm.deal(address(this), 1 ether);
+		swapper.onRampAndSwap{ value: 1 ether }(user, 0);
+		// No revert means success, excess was sent
+	}
+
+	function test_RevertWhen_SlippageTooHigh() public {
+		// Create a new router that returns less tokens than expected
+		MockRouter lowOutputRouter = new MockRouter(address(ctzn));
+		OnRampSwapper newSwapper = new OnRampSwapper(
+			address(lowOutputRouter),
+			address(ctzn),
+			address(wmatic),
+			treasury
+		);
+
+		// Set up the test with a high minimum output amount
+		uint256 amountIn = 1 ether;
+		uint256 minOutput = 3 ether; // Expecting 2x output but setting minimum to 3x
+
+		vm.deal(address(this), amountIn);
+		vm.expectRevert(abi.encodeWithSelector(OnRampSwapper.InsufficientOutputAmount.selector, 2 ether, 3 ether));
+		newSwapper.onRampAndSwap{ value: amountIn }(user, minOutput);
+	}
+
+	function test_RevertWhen_ReentrancyAttempt() public {
+		// Create malicious contract
+		MaliciousReentrant malicious = new MaliciousReentrant(payable(address(swapper)), user);
+		
+		// Set the malicious contract as the callback target in the router
+		router.setCallback(address(malicious));
+		
+		// Fund the malicious contract
+		vm.deal(address(malicious), 1 ether);
+		
+		// Attempt the initial swap which will trigger the reentrancy attempt
+		vm.expectRevert();
+		malicious.onERC20Received();
+	}
+
 }

--- a/test/OnRampSwapper.t.sol
+++ b/test/OnRampSwapper.t.sol
@@ -65,7 +65,7 @@ contract RevertingReceiver {
     }
 }
 
-contract MockWMATIC is IWMATIC {
+contract MockWPOL is IWPOL {
     receive() external payable {}
 
     function deposit() external payable override {}
@@ -81,15 +81,15 @@ contract OnRampSwapperTest is Test {
     MockRouter public router;
     address public treasury = address(0xBEEF);
     address public user = address(0xABCD);
-    MockWMATIC public wmatic;
+    MockWPOL public wpol;
 
     receive() external payable {}
 
     function setUp() public {
         ctzn = new MockCTZN();
         router = new MockRouter(address(ctzn));
-        wmatic = new MockWMATIC();
-        swapper = new OnRampSwapper(address(router), address(ctzn), address(wmatic), treasury);
+        wpol = new MockWPOL();
+        swapper = new OnRampSwapper(address(router), address(ctzn), address(wpol), treasury);
         vm.deal(address(this), 100 ether);
         vm.deal(user, 10 ether);
     }
@@ -98,7 +98,7 @@ contract OnRampSwapperTest is Test {
         assertEq(swapper.ctznToken(), address(ctzn));
         assertEq(swapper.quickswapRouter(), address(router));
         assertEq(swapper.treasuryAddress(), treasury);
-        assertEq(swapper.wmatic(), address(wmatic));
+        assertEq(swapper.wpol(), address(wpol));
     }
     function testOnRampAndSwap() public {
         address recipient = address(0x1234);
@@ -142,15 +142,15 @@ contract OnRampSwapperTest is Test {
     }
     
     function testFailConstructorZeroRouter() public {
-    new OnRampSwapper(address(0), address(ctzn), address(wmatic), treasury);
+    new OnRampSwapper(address(0), address(ctzn), address(wpol), treasury);
     }
 
     function testFailConstructorZeroCTZN() public {
-        new OnRampSwapper(address(router), address(0), address(wmatic), treasury);
+        new OnRampSwapper(address(router), address(0), address(wpol), treasury);
     }
 
     function testFailConstructorZeroTreasury() public {
-        new OnRampSwapper(address(router), address(ctzn), address(wmatic), address(0));
+        new OnRampSwapper(address(router), address(ctzn), address(wpol), address(0));
     }
 
 


### PR DESCRIPTION
**Description**
This PR adds the OnRampSwapper smart contract, designed to facilitate fiat-to-crypto on-ramping. The contract is intended to be called by Transak after a successful fiat payment, allowing the received native POL (MATIC) to be swapped for CTZN tokens via QuickSwap.

**Features**
- Swaps incoming native POL to CTZN using QuickSwap.
- Sends CTZN directly to the user-specified recipient.
- Forwards any excess POL to a predefined treasury address.
- Includes admin controls for treasury updates and emergency POL withdrawal.
- Protected against reentrancy attacks.

